### PR TITLE
Add Locate v2 API support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ add_test(NAME other_unit_tests COMMAND tests-libndt)
 add_test(NAME sys_unit_tests COMMAND sys_test)
 
 add_test(NAME simple_test COMMAND libndt-client
-         -ndt7 -download -upload -verbose)
+         -download -upload -verbose)
 add_test(NAME modern_test COMMAND libndt-client
          -ca-bundle-path ${CMAKE_SOURCE_DIR}/third_party/curl.haxx.se/ca/cacert.pem
-         -verbose -ndt7 -download -upload -tls -websocket)
+         -verbose -download -upload -tls)

--- a/include/libndt/libndt.hpp
+++ b/include/libndt/libndt.hpp
@@ -904,7 +904,6 @@ bool Client::run() noexcept {
     if ((settings_.nettest_flags & nettest_flag_download) != 0) {
       auto url = urls[scheme+":///ndt/v7/download"];
       UrlParts parts = parse_ws_url(url);
-      LIBNDT_EMIT_INFO("url: " << std::string(url) << " " << parts.scheme << " " << parts.host);
       if (!ndt7_download(parts)) {
         LIBNDT_EMIT_WARNING("ndt7: download failed");
         // FALLTHROUGH
@@ -913,7 +912,6 @@ bool Client::run() noexcept {
     if ((settings_.nettest_flags & nettest_flag_upload) != 0) {
       auto url = urls[scheme+":///ndt/v7/upload"];
       UrlParts parts = parse_ws_url(url);
-      LIBNDT_EMIT_INFO("url: " << std::string(url) << " " << parts.scheme << " " << parts.host);
       if (!ndt7_upload(parts)) {
         LIBNDT_EMIT_WARNING("ndt7: upload failed");
         // FALLTHROUGH
@@ -1061,7 +1059,7 @@ bool Client::query_locate_api(const std::map<std::string, std::string>& opts, st
 // `````````````````
 
 bool Client::ndt7_download(UrlParts url) noexcept {
-  LIBNDT_EMIT_INFO("starting ndt7 download test");
+  LIBNDT_EMIT_INFO("starting ndt7 download test: " << url.scheme << "://" << url.host);
   if (!ndt7_connect(url)) {
     return false;
   }
@@ -1144,8 +1142,7 @@ bool Client::ndt7_download(UrlParts url) noexcept {
 }
 
 bool Client::ndt7_upload(UrlParts url) noexcept {
-  LIBNDT_EMIT_INFO("starting ndt7 upload test");
-  LIBNDT_EMIT_INFO("starting ndt7 upload test: " << url.scheme << " " << url.host);
+  LIBNDT_EMIT_INFO("starting ndt7 upload test: " << url.scheme << "://" << url.host);
   if (!ndt7_connect(url)) {
     return false;
   }
@@ -2011,10 +2008,10 @@ internal::Err Client::netx_maybessl_dial(const std::string &hostname,
   LIBNDT_EMIT_DEBUG(
       "netx_maybessl_dial: netx_maybesocks5h_dial() returned successfully");
   if ((settings_.protocol_flags & protocol_flag_tls) == 0) {
-    LIBNDT_EMIT_INFO("netx_maybessl_dial: TLS not enabled");
+    LIBNDT_EMIT_DEBUG("netx_maybessl_dial: TLS not enabled");
     return internal::Err::none;
   }
-  LIBNDT_EMIT_INFO("netx_maybetls_dial: about to start TLS handshake");
+  LIBNDT_EMIT_DEBUG("netx_maybetls_dial: about to start TLS handshake");
   if (settings_.ca_bundle_path.empty() && settings_.tls_verify_peer) {
 #ifndef _WIN32
     // See <https://serverfault.com/a/722646>

--- a/include/libndt/libndt.hpp
+++ b/include/libndt/libndt.hpp
@@ -288,7 +288,8 @@ class Settings {
   /// the client version and the application.
   std::map<std::string, std::string> metadata{
       {"client_version", ndt_client_version},
-      {"client_name", "m-lab/ndt7-client-cc"},
+      {"client_library", "m-lab/ndt7-client-cc"},
+      // TODO: add build option for specifying client_name.
   };
 
   /// Type of NDT protocol that you want to use. Selecting the protocol may

--- a/include/libndt/libndt.hpp
+++ b/include/libndt/libndt.hpp
@@ -288,7 +288,7 @@ class Settings {
   /// the client version and the application.
   std::map<std::string, std::string> metadata{
       {"client_version", ndt_client_version},
-      {"client_application", "m-lab/ndt7-client-cc"},
+      {"client_name", "m-lab/ndt7-client-cc"},
   };
 
   /// Type of NDT protocol that you want to use. Selecting the protocol may

--- a/include/libndt/libndt.hpp
+++ b/include/libndt/libndt.hpp
@@ -119,18 +119,7 @@ struct UrlParts {
 
 UrlParts parse_ws_url(const std::string& url);
 
-std::string format_http_params(const std::map<std::string, std::string>& params) {
-  std::stringstream ss;
-  bool first = true;
-  for (const auto& kv : params) {
-    if (!first) {
-      ss << "&";
-    }
-    ss << kv.first << "=" << kv.second;
-    first = false;
-  }
-  return ss.str();
-}
+std::string format_http_params(const std::map<std::string, std::string>& params);
 
 // Versioning
 // ``````````
@@ -2963,6 +2952,19 @@ UrlParts parse_ws_url(const std::string& url) {
   }
 
   return parts;
+}
+
+std::string format_http_params(const std::map<std::string, std::string>& params) {
+  std::stringstream ss;
+  bool first = true;
+  for (const auto& kv : params) {
+    if (!first) {
+      ss << "&";
+    }
+    ss << kv.first << "=" << kv.second;
+    first = false;
+  }
+  return ss.str();
 }
 
 }  // namespace libndt

--- a/include/libndt/libndt.hpp
+++ b/include/libndt/libndt.hpp
@@ -1029,9 +1029,9 @@ bool Client::query_locate_api(const std::map<std::string, std::string>& opts, st
   // error, the object includes an "error". On success, there is always at least
   // one result in an array.
   if (!json.contains("results")) {
-    // TODO: read error, return false.
     if (!json.contains("error")) {
       LIBNDT_EMIT_WARNING("no results and no error! " << body);
+      return false;
     }
     auto err = json["error"];
     LIBNDT_EMIT_WARNING("error response from " << locate_api_url << ": " << err);
@@ -1047,11 +1047,12 @@ bool Client::query_locate_api(const std::map<std::string, std::string>& opts, st
     auto result_urls = target["urls"];
     do {
       auto it = result_urls.begin();
+      // Any key is fine for debug logging.
       LIBNDT_EMIT_DEBUG("discovered host: " << result_urls[it.key()]);
     } while(0);
     urls->push_back(std::move(result_urls));
   }
-  return true;
+  return urls->size() > 0;
 }
 
 // ndt7 protocol API

--- a/include/libndt/libndt.hpp
+++ b/include/libndt/libndt.hpp
@@ -109,6 +109,16 @@
 namespace measurement_kit {
 namespace libndt {
 
+// Structure to store extracted URL parts
+struct UrlParts {
+  std::string scheme;
+  std::string host;
+  std::string port;
+  std::string path;
+};
+
+UrlParts parse_ws_url(const std::string& url);
+
 // Versioning
 // ``````````
 
@@ -172,23 +182,6 @@ constexpr ProtocolFlags protocol_flag_websocket = ProtocolFlags{1 << 2};
 /// means that a totally different protocol is used. You can read more on ndt7
 /// at https://github.com/m-lab/ndt-server/blob/master/spec/ndt7-protocol.md
 constexpr ProtocolFlags protocol_flag_ndt7 = ProtocolFlags{1 << 3};
-
-// Policy for auto-selecting a NDT server
-// ``````````````````````````````````````
-
-/// Flags modifying the behavior of mlab-ns. Mlab-ns is the web service used
-/// to automatically discover NDT's (and other experiments') servers.
-using MlabnsPolicy = unsigned short;
-
-/// Request just the closest NDT server.
-constexpr MlabnsPolicy mlabns_policy_closest = MlabnsPolicy{0};
-
-/// Request for a random NDT server.
-constexpr MlabnsPolicy mlabns_policy_random = MlabnsPolicy{1};
-
-/// Return a list of nearby NDT servers. When more than one server is returned
-/// all the available servers will be tried in case some of them are down.
-constexpr MlabnsPolicy mlabns_policy_geo_options = MlabnsPolicy{2};
 
 // EventHandler
 // ------------
@@ -259,26 +252,22 @@ EventHandler::~EventHandler() noexcept {}
 // Settings
 // ````````
 
-constexpr const char *ndt_version_compat = "v3.7.0";
+constexpr const char *ndt_version_compat = "v7.0.0";
 
 /// NDT client settings. If you do not customize the settings when creating
 /// a Client, the defaults listed below will be used instead.
 class Settings {
  public:
-  /// Base URL to be used to query the mlab-ns service. If you specify an
-  /// explicit hostname, mlab-ns won't be used. Note that the URL specified
+  /// Base URL to be used to query the Locate API service. If you specify an
+  /// explicit hostname, Locate API won't be used. Note that the URL specified
   /// here MUST NOT end with a final slash.
-  std::string mlabns_base_url = "https://locate.measurementlab.net";
-
-  /// Flags that modify the behavior of mlabn-ns. By default we use the
-  /// geo_options policy that is the most robust to random server failures.
-  MlabnsPolicy mlabns_policy = mlabns_policy_geo_options;
+  std::string locate_api_base_url = "https://locate.measurementlab.net";
 
   /// Timeout used for I/O operations.
   Timeout timeout = Timeout{7} /* seconds */;
 
   /// Host name of the NDT server to use. If this is left blank (the default),
-  /// we will use mlab-ns to discover a nearby server.
+  /// we will use Locate API to discover a nearby server.
   std::string hostname;
 
   /// Port of the NDT server to use. If this is not specified, we will use
@@ -294,17 +283,15 @@ class Settings {
   Verbosity verbosity = verbosity_quiet;
 
   /// Metadata to include in the server side logs. By default we just identify
-  /// the NDT version and the application.
+  /// the client version and the application.
   std::map<std::string, std::string> metadata{
-      {"client.version", ndt_version_compat},
-      {"client.application", "measurement-kit/libndt"},
+      {"client_version", ndt_version_compat},
+      {"client_application", "m-lab/ndt7-client-cc"},
   };
 
   /// Type of NDT protocol that you want to use. Selecting the protocol may
   /// cause libndt to use different default settings for the port or for
-  /// mlab-ns. Clear text NDT uses port 3001, NDT-over-TLS uses 3010. There
-  /// will most likely be servers listening on port 443 in the future, but
-  /// they will only support the TLS+WebSocket protocol.
+  /// the Locate API. Clear text ndt7 uses port 80, ndt7-over-TLS uses 443.
   ProtocolFlags protocol_flags = ProtocolFlags{0};
 
   /// Maximum time for which a nettest (i.e. download) is allowed to run. After
@@ -410,7 +397,7 @@ class Client : public EventHandler {
 
   // High-level API
   virtual void summary() noexcept;
-  virtual bool query_mlabns(std::vector<std::string> *) noexcept;
+  virtual bool query_locate_api(std::string opts, std::vector<nlohmann::json> *urls) noexcept;
 
   // ndt7 protocol API
   // `````````````````
@@ -422,13 +409,13 @@ class Client : public EventHandler {
 
   // ndt7_download performs a ndt7 download. Returns true if the download
   // succeeds and false in case of failure.
-  bool ndt7_download() noexcept;
+  bool ndt7_download(UrlParts url) noexcept;
 
   // ndt7_upload is like ndt7_download but performs an upload.
-  bool ndt7_upload() noexcept;
+  bool ndt7_upload(UrlParts url) noexcept;
 
   // ndt7_connect connects to @p url_path.
-  bool ndt7_connect(std::string url_path) noexcept;
+  bool ndt7_connect(UrlParts url) noexcept;
 
   // WebSocket
   // `````````
@@ -580,7 +567,7 @@ class Client : public EventHandler {
   // Close a socket.
   virtual internal::Err netx_closesocket(internal::Socket fd) noexcept;
 
-  virtual bool query_mlabns_curl(const std::string &url, long timeout,
+  virtual bool query_locate_api_curl(const std::string &url, long timeout,
                                  std::string *body) noexcept;
 
   // Other helpers
@@ -906,38 +893,29 @@ Client::~Client() noexcept {
 // `````````````
 
 bool Client::run() noexcept {
-  std::vector<std::string> fqdns;
-  if (!query_mlabns(&fqdns)) {
+  std::vector<nlohmann::json> targets;
+  if (!query_locate_api("", &targets)) {
     return false;
   }
-  for (auto &fqdn : fqdns) {
-    LIBNDT_EMIT_DEBUG("trying to connect to " << fqdn);
-    settings_.hostname = fqdn;
-    // TODO(bassosimone): we will eventually want to refactor the code to
-    // make ndt7 the default and ndt5 the optional case.
-    if ((settings_.protocol_flags & protocol_flag_ndt7) != 0) {
-      LIBNDT_EMIT_DEBUG("using the ndt7 protocol");
-      if ((settings_.nettest_flags & nettest_flag_download) != 0) {
-        // TODO(bassosimone): for now we do not try with more than one host
-        // when using ndt7 and there's a failure. We may want to do that.
-        if (!ndt7_download()) {
-          LIBNDT_EMIT_WARNING("ndt7: download failed");
-          // FALLTHROUGH
-        }
+  for (auto &urls : targets) {
+    LIBNDT_EMIT_DEBUG("using the ndt7 protocol");
+    if ((settings_.nettest_flags & nettest_flag_download) != 0) {
+      auto url = urls["wss:///ndt/v7/download"];
+      UrlParts parts = parse_ws_url(url);
+      if (!ndt7_download(parts)) {
+        LIBNDT_EMIT_WARNING("ndt7: download failed");
+        // FALLTHROUGH
       }
-      if ((settings_.nettest_flags & nettest_flag_upload) != 0) {
-        // TODO(bassosimone): same as above.
-        if (!ndt7_upload()) {
-          LIBNDT_EMIT_WARNING("ndt7: upload failed");
-          // FALLTHROUGH
-        }
-      }
-      LIBNDT_EMIT_INFO("ndt7: test complete");
-      // TODO(bassosimone): here we may want to warn if the user selects
-      // subtests that we actually do not implement.
-      return true;
     }
-    LIBNDT_EMIT_DEBUG("connection closed");
+    if ((settings_.nettest_flags & nettest_flag_upload) != 0) {
+      auto url = urls["wss:///ndt/v7/upload"];
+      UrlParts parts = parse_ws_url(url);
+      if (!ndt7_upload(parts)) {
+        LIBNDT_EMIT_WARNING("ndt7: upload failed");
+        // FALLTHROUGH
+      }
+    }
+    LIBNDT_EMIT_INFO("ndt7: test complete");
     return true;
   }
   LIBNDT_EMIT_WARNING("no more hosts to try; failing the test");
@@ -1015,29 +993,29 @@ void Client::summary() noexcept {
   }
 }
 
-bool Client::query_mlabns(std::vector<std::string> *fqdns) noexcept {
-  assert(fqdns != nullptr);
+bool Client::query_locate_api(std::string opts, std::vector<nlohmann::json> *urls) noexcept {
+  assert(urls != nullptr);
   if (!settings_.hostname.empty()) {
-    LIBNDT_EMIT_DEBUG("no need to query mlab-ns; we have hostname");
+    LIBNDT_EMIT_DEBUG("no need to query locate api; we have hostname");
     // When we already know the hostname that we want to use just fake out the
-    // result of a mlabns query as like mlabns returned that hostname.
-    fqdns->push_back(std::move(settings_.hostname));
+    // result of a locate_api query as like locate_api returned that hostname.
+    urls->push_back(std::move(settings_.hostname));
     return true;
   }
-  std::string mlabns_url = settings_.mlabns_base_url;
-  if ((settings_.protocol_flags & protocol_flag_ndt7) != 0) {
-    mlabns_url += "/ndt7";
-  }
-  if (settings_.mlabns_policy == mlabns_policy_random) {
-    mlabns_url += "?policy=random";
-  } else if (settings_.mlabns_policy == mlabns_policy_geo_options) {
-    mlabns_url += "?policy=geo_options";
+  std::string locate_api_url = settings_.locate_api_base_url;
+  locate_api_url += "/v2/nearest/ndt/ndt7";
+  if (opts.length() > 0) {
+    // TODO(soltesz): generalize options for country, region, or lat/lon, etc?
+    // TODO(soltesz): add client metadata.
+    locate_api_url += "?" + opts;
   }
   std::string body;
-  if (!query_mlabns_curl(mlabns_url, settings_.timeout, &body)) {
+  LIBNDT_EMIT_DEBUG("locate_api url: " << locate_api_url);
+  if (!query_locate_api_curl(locate_api_url, settings_.timeout, &body)) {
+
     return false;
   }
-  LIBNDT_EMIT_DEBUG("mlabns reply: " << body);
+  LIBNDT_EMIT_DEBUG("locate_api reply: " << body);
   nlohmann::json json;
   try {
     json = nlohmann::json::parse(body);
@@ -1045,24 +1023,32 @@ bool Client::query_mlabns(std::vector<std::string> *fqdns) noexcept {
     LIBNDT_EMIT_WARNING("cannot parse JSON: " << exc.what());
     return false;
   }
-  // In some cases mlab-ns returns a single object but in other cases (e.g.
-  // with the `geo_options` policy) it returns an array. Always make an
-  // array so that we can write uniform code for processing mlab-ns response.
-  if (json.is_object()) {
-    auto array = nlohmann::json::array();
-    array.push_back(json);
-    std::swap(json, array);
-  }
-  for (auto &entry : json) {
-    std::string fqdn;
-    try {
-      fqdn = entry.at("fqdn").get<std::string>();
-    } catch (const nlohmann::json::exception &exc) {
-      LIBNDT_EMIT_WARNING("cannot access FQDN field: " << exc.what());
-      return false;
+
+  // On success, the Locate API returns an object with a "results" array. On
+  // error, the object includes an "error". On success, there is always at least
+  // one result in an array.
+  if (!json.contains("results")) {
+    // TODO: read error, return false.
+    if (!json.contains("error")) {
+      LIBNDT_EMIT_WARNING("no results and no error! " << body);
     }
-    LIBNDT_EMIT_DEBUG("discovered host: " << fqdn);
-    fqdns->push_back(std::move(fqdn));
+    auto err = json["error"];
+    LIBNDT_EMIT_WARNING("error response from " << locate_api_url << ": " << err);
+    return false;
+  }
+  auto results = json["results"];
+  for (auto &target : results) {
+    if (!target.contains("urls")) {
+      // This should not occur.
+      LIBNDT_EMIT_WARNING("results object is missing urls: " << body);
+      continue;
+    }
+    auto result_urls = target["urls"];
+    do {
+      auto it = result_urls.begin();
+      LIBNDT_EMIT_DEBUG("discovered host: " << result_urls[it.key()]);
+    } while(0);
+    urls->push_back(std::move(result_urls));
   }
   return true;
 }
@@ -1070,9 +1056,9 @@ bool Client::query_mlabns(std::vector<std::string> *fqdns) noexcept {
 // ndt7 protocol API
 // `````````````````
 
-bool Client::ndt7_download() noexcept {
+bool Client::ndt7_download(UrlParts url) noexcept {
   LIBNDT_EMIT_INFO("starting ndt7 download test");
-  if (!ndt7_connect("/ndt/v7/download")) {
+  if (!ndt7_connect(url)) {
     return false;
   }
   // The following value is the maximum amount of bytes that an implementation
@@ -1153,9 +1139,9 @@ bool Client::ndt7_download() noexcept {
   return true;
 }
 
-bool Client::ndt7_upload() noexcept {
+bool Client::ndt7_upload(UrlParts url) noexcept {
   LIBNDT_EMIT_INFO("starting ndt7 upload test");
-  if (!ndt7_connect("/ndt/v7/upload")) {
+  if (!ndt7_connect(url)) {
     return false;
   }
   // Implementation note: we send messages smaller than the maximum message
@@ -1242,11 +1228,7 @@ bool Client::ndt7_upload() noexcept {
   return true;
 }
 
-bool Client::ndt7_connect(std::string url_path) noexcept {
-  std::string port = "443";
-  if (!settings_.port.empty()) {
-    port = settings_.port;
-  }
+bool Client::ndt7_connect(UrlParts url) noexcept {
   // Don't leak resources if the socket is already open.
   if (internal::IsSocketValid(sock_)) {
     LIBNDT_EMIT_DEBUG("ndt7: closing socket openned in previous attempt");
@@ -1256,10 +1238,10 @@ bool Client::ndt7_connect(std::string url_path) noexcept {
   // Note: ndt7 implies WebSocket and TLS
   settings_.protocol_flags |= protocol_flag_websocket | protocol_flag_tls;
 	internal::Err err = netx_maybews_dial(
-      settings_.hostname, port,
+      url.host, url.port,
       ws_f_connection | ws_f_upgrade | ws_f_sec_ws_accept |
           ws_f_sec_ws_protocol,
-      ws_proto_ndt7, url_path, &sock_);
+      ws_proto_ndt7, url.path, &sock_);
   if (err != internal::Err::none) {
     return false;
   }
@@ -2920,7 +2902,7 @@ class CurlxLoggerAdapter : public internal::Logger {
   Client *client_;
 };
 
-bool Client::query_mlabns_curl(const std::string &url, long timeout,
+bool Client::query_locate_api_curl(const std::string &url, long timeout,
                                std::string *body) noexcept {
   CurlxLoggerAdapter adapter{this};
   internal::Curlx curlx{adapter};
@@ -2932,6 +2914,43 @@ bool Client::query_mlabns_curl(const std::string &url, long timeout,
 
 Verbosity Client::get_verbosity() const noexcept {
   return settings_.verbosity;
+}
+
+// Function to parse a websocket URL and return its components.
+UrlParts parse_ws_url(const std::string& url) {
+  UrlParts parts;
+
+  // Find the scheme.
+  auto colon_pos = url.find(":");
+  if (colon_pos != std::string::npos) {
+    parts.scheme = url.substr(0, colon_pos);
+  }
+
+  // Extract the hostname and port.
+  auto slash_pos = url.find("/", colon_pos + 3);
+  if (slash_pos != std::string::npos) {
+    auto host_part = url.substr(colon_pos + 3, slash_pos - colon_pos - 3);
+    auto port_pos = host_part.find(":");
+    // Does the host include a port?
+    if (port_pos != std::string::npos) {
+      parts.host = host_part.substr(0, port_pos);
+      parts.port = host_part.substr(port_pos + 1);
+    } else {
+      parts.host = host_part;
+      if (parts.scheme == "ws") {
+        parts.port = "80";
+      } else if (parts.scheme == "wss") {
+        parts.port = "443";
+      }
+    }
+  }
+
+  // Extract the path.
+  if (slash_pos != std::string::npos) {
+    parts.path = url.substr(slash_pos);
+  }
+
+  return parts;
 }
 
 }  // namespace libndt

--- a/include/libndt/libndt.hpp
+++ b/include/libndt/libndt.hpp
@@ -249,8 +249,6 @@ EventHandler::~EventHandler() noexcept {}
 // Settings
 // ````````
 
-constexpr const char *ndt_client_version = "v0.1.0";
-
 /// NDT client settings. If you do not customize the settings when creating
 /// a Client, the defaults listed below will be used instead.
 class Settings {
@@ -282,8 +280,8 @@ class Settings {
   /// Metadata to include in the server side logs. By default we just identify
   /// the client version and the library.
   std::map<std::string, std::string> metadata{
-      {"client_version", ndt_client_version},
-      {"client_library", "m-lab/ndt7-client-cc"},
+      {"client_library_version", "v0.1.0"},
+      {"client_library_name", "m-lab/ndt7-client-cc"},
       // TODO: add build option for specifying client_name.
   };
 

--- a/libndt-client.cpp
+++ b/libndt-client.cpp
@@ -158,9 +158,6 @@ int main(int, char **argv) {
       } else if (flag == "insecure") {
         settings.tls_verify_peer = false;
         std::clog << "WILL NOT verify the TLS peer (INSECURE!)" << std::endl;
-      } else if (flag == "ndt7") {
-        settings.protocol_flags |= libndt::protocol_flag_ndt7;
-        std::clog << "will use the ndt7 protocol" << std::endl;
       } else if (flag == "tls") {
         settings.protocol_flags |= libndt::protocol_flag_tls;
         std::clog << "will secure communications using TLS" << std::endl;
@@ -174,9 +171,6 @@ int main(int, char **argv) {
         std::cout << libndt::version_major << "." << libndt::version_minor
                   << "." << libndt::version_patch << std::endl;
         exit(EXIT_SUCCESS);
-      } else if (flag == "websocket") {
-        settings.protocol_flags |= libndt::protocol_flag_websocket;
-        std::clog << "will use the NDT-over-WebSocket protocol" << std::endl;
       } else if (flag == "batch") {
         batch_mode = true;
         std::clog << "will run in batch mode" << std::endl;

--- a/libndt-client.cpp
+++ b/libndt-client.cpp
@@ -161,11 +161,6 @@ int main(int, char **argv) {
       } else if (flag == "ndt7") {
         settings.protocol_flags |= libndt::protocol_flag_ndt7;
         std::clog << "will use the ndt7 protocol" << std::endl;
-      } else if (flag == "random") {
-        std::clog << "WARNING: the `-random` flag is deprecated" << std::endl;
-        std::clog << "HINT: replace with `-lookup-policy random`" << std::endl;
-        settings.mlabns_policy = libndt::mlabns_policy_random;
-        std::clog << "will auto-select a random server" << std::endl;
       } else if (flag == "tls") {
         settings.protocol_flags |= libndt::protocol_flag_tls;
         std::clog << "will secure communications using TLS" << std::endl;
@@ -198,19 +193,6 @@ int main(int, char **argv) {
       if (param.first == "ca-bundle-path") {
         settings.ca_bundle_path = param.second;
         std::clog << "will use this CA bundle: " << param.second << std::endl;
-      } else if (param.first == "lookup-policy") {
-        if (param.second == "closest") {
-          settings.mlabns_policy = libndt::mlabns_policy_closest;
-        } else if (param.second == "random") {
-          settings.mlabns_policy = libndt::mlabns_policy_random;
-        } else if (param.second == "geo-options") {
-          settings.mlabns_policy = libndt::mlabns_policy_geo_options;
-        } else {
-          std::clog << "fatal: unrecognized -lookup-policy: " << param.second
-                    << std::endl << std::endl;
-          usage();
-          exit(EXIT_FAILURE);
-        }
       } else if (param.first == "port") {
         settings.port = param.second;
         std::clog << "will use this port: " << param.second << std::endl;

--- a/test/libndt_test.cpp
+++ b/test/libndt_test.cpp
@@ -48,7 +48,7 @@ using namespace measurement_kit::libndt;
 class FailQueryMlabns : public Client {
  public:
   using Client::Client;
-  bool query_locate_api(const std::map<std::string, std::string>& opts, std::vector<nlohmann::json> *urls) noexcept override {
+  bool query_locate_api(const std::map<std::string, std::string>&, std::vector<nlohmann::json>*) noexcept override {
     return false;
   }
 };

--- a/test/libndt_test.cpp
+++ b/test/libndt_test.cpp
@@ -48,12 +48,12 @@ using namespace measurement_kit::libndt;
 class FailQueryMlabns : public Client {
  public:
   using Client::Client;
-  bool query_mlabns(std::vector<std::string> *) noexcept override {
+  bool query_locate_api(const std::map<std::string, std::string>& opts, std::vector<nlohmann::json> *urls) noexcept override {
     return false;
   }
 };
 
-TEST_CASE("Client::run() deals with Client::query_mlabns() failure") {
+TEST_CASE("Client::run() deals with Client::query_locate_api() failure") {
   FailQueryMlabns client;
   REQUIRE(client.run() == false);
 }
@@ -66,79 +66,85 @@ TEST_CASE("Client::on_warning() works as expected") {
   client.on_warning("calling on_warning() to increase coverage");
 }
 
-// Client::query_mlabns() tests
+// Client::query_locate_api() tests
 // ----------------------------
 
 class FailQueryMlabnsCurl : public Client {
  public:
   using Client::Client;
-  bool query_mlabns_curl(const std::string &, long,
+  bool query_locate_api_curl(const std::string &, long,
                          std::string *) noexcept override {
     return false;
   }
 };
 
-TEST_CASE("Client::query_mlabns() does nothing when we already know hostname") {
+TEST_CASE("Client::query_locate_api() does nothing when we already know hostname") {
   Settings settings;
   settings.hostname = "neubot.mlab.mlab1.trn01.measurement-lab.org";
   FailQueryMlabnsCurl client{settings};
   std::vector<std::string> v;
-  REQUIRE(client.query_mlabns(&v) == true);
+  std::vector<nlohmann::json> targets;
+  std::map<std::string, std::string> metadata;
+  REQUIRE(client.query_locate_api(metadata, &targets) == true);
 }
 
 TEST_CASE(
-    "Client::query_mlabns() deals with Client::query_mlabns_curl() failure") {
+    "Client::query_locate_api() deals with Client::query_locate_api_curl() failure") {
   FailQueryMlabnsCurl client;
-  std::vector<std::string> v;
-  REQUIRE(client.query_mlabns(&v) == false);
+  std::vector<nlohmann::json> targets;
+  std::map<std::string, std::string> metadata;
+  REQUIRE(client.query_locate_api(metadata, &targets) == false);
 }
 
 class EmptyMlabnsJson : public Client {
  public:
   using Client::Client;
-  bool query_mlabns_curl(const std::string &, long,
+  bool query_locate_api_curl(const std::string &, long,
                          std::string *body) noexcept override {
     *body = "";
     return true;
   }
 };
 
-TEST_CASE("Client::query_mlabns() deals with empty JSON") {
+TEST_CASE("Client::query_locate_api() deals with empty JSON") {
   EmptyMlabnsJson client;
-  std::vector<std::string> v;
-  REQUIRE(client.query_mlabns(&v) == false);
+  std::vector<nlohmann::json> targets;
+  std::map<std::string, std::string> metadata;
+  REQUIRE(client.query_locate_api(metadata, &targets) == false);
 }
 
 class InvalidMlabnsJson : public Client {
  public:
   using Client::Client;
-  bool query_mlabns_curl(const std::string &, long,
+  bool query_locate_api_curl(const std::string &, long,
                          std::string *body) noexcept override {
     *body = "{{{{";
     return true;
   }
 };
 
-TEST_CASE("Client::query_mlabns() deals with invalid JSON") {
+TEST_CASE("Client::query_locate_api() deals with invalid JSON") {
   InvalidMlabnsJson client;
-  std::vector<std::string> v;
-  REQUIRE(client.query_mlabns(&v) == false);
+  std::vector<nlohmann::json> targets;
+  std::map<std::string, std::string> metadata;
+  REQUIRE(client.query_locate_api(metadata, &targets) == false);
 }
 
 class IncompleteMlabnsJson : public Client {
  public:
   using Client::Client;
-  bool query_mlabns_curl(const std::string &, long,
+  bool query_locate_api_curl(const std::string &, long,
                          std::string *body) noexcept override {
     *body = "{}";
     return true;
   }
 };
 
-TEST_CASE("Client::query_mlabns() deals with incomplete JSON") {
+TEST_CASE("Client::query_locate_api() deals with incomplete JSON") {
   IncompleteMlabnsJson client;
-  std::vector<std::string> v;
-  REQUIRE(client.query_mlabns(&v) == false);
+  std::vector<nlohmann::json> targets;
+  std::map<std::string, std::string> metadata;
+  REQUIRE(client.query_locate_api(metadata, &targets) == false);
 }
 
 // Client::netx_maybesocks5h_dial() tests
@@ -1390,15 +1396,15 @@ TEST_CASE("Client::netx_poll() deals with timeout") {
   REQUIRE(client.netx_poll(&pfds, timeout) == internal::Err::timed_out);
 }
 
-// Client::query_mlabns_curl() tests
+// Client::query_locate_api_curl() tests
 // ---------------------------------
 
 #ifdef HAVE_CURL
-TEST_CASE("Client::query_mlabns_curl() deals with Curl{} failure") {
+TEST_CASE("Client::query_locate_api_curl() deals with Curl{} failure") {
   Client client;
   // Note: passing `nullptr` should cause Curl{} to fail and hence we can
   // also easily check for cases where Curl{} fails.
-  REQUIRE(client.query_mlabns_curl("", 3, nullptr) == false);
+  REQUIRE(client.query_locate_api_curl("", 3, nullptr) == false);
 }
 #endif
 


### PR DESCRIPTION
This change adds support for the Locate v2 API, and removes legacy logic for the deprecated mlab-ns. With these changes, the reference client is able to complete an ndt7 test targeting the M-lab platform using access tokens received from the Locate v2 API.

The client will unconditionally report the client_name, client_version, and client_application strings in the locate request which will be forwarded to the ndt7 server and archived with test data.

```
$ ./ndt7-cpp -download -upload
will run the download sub-test
will run the upload sub-test
will auto-select a suitable server
locate_api url: https://locate.measurementlab.net/v2/nearest/ndt/ndt7?client_application=m-lab/ndt7-client-cc&client_version=v0.1.0
starting ndt7 download test
  [ 2%] speed:    428 Mbit/s
  [ 4%] speed:    475 Mbit/s
  [ 6%] speed:    489 Mbit/s
  [ 7%] speed:    498 Mbit/s
  ...
starting ndt7 upload test
  [ 3%] speed:   60.5 Mbit/s
  [15%] speed:   10.1 Mbit/s
  [18%] speed:   9.68 Mbit/s
  [20%] speed:     11 Mbit/s
  ...  
ndt7: test complete
[Test results]
Download speed:    521 Mbit/s
Upload speed:   18.9 Mbit/s
Latency: 4.91 ms
```

Part of:
* https://github.com/m-lab/ndt7-client-cc/issues/2

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-cc/5)
<!-- Reviewable:end -->
