### PR TITLE
Update libndt-client flags and support static targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ add_test(NAME other_unit_tests COMMAND tests-libndt)
 add_test(NAME sys_unit_tests COMMAND sys_test)
 
 add_test(NAME simple_test COMMAND libndt-client
-         -download -upload -verbose)
+         -download -upload -verbose -scheme=ws)
 add_test(NAME modern_test COMMAND libndt-client
          -ca-bundle-path ${CMAKE_SOURCE_DIR}/third_party/curl.haxx.se/ca/cacert.pem
-         -verbose -download -upload -tls)
+         -verbose -download -upload -scheme=wss)

--- a/README.md
+++ b/README.md
@@ -37,8 +37,12 @@ a file named `main.cpp` with this content.
 
 int main() {
   using namespace measurement_kit;
-  libndt::Client client;
-  client.run();
+  libndt::Settings settings;
+  std::unique_ptr<libndt::Client>  client;
+  settings.metadata["client_name"] = CLIENT_NAME;
+  settings.metadata["client_version"] = CLIENT_VERSION;
+  client.reset(new libndt::Client{settings});
+  client->run();
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ int main() {
 Compile your client with a unique name using:
 
 ```sh
-g++ -std=c++11 -Wall -Wextra -DCLIENT_NAME=\"my-ndt7-client\" -I. -o main main.cpp
+g++ -std=c++11 -Wall -Wextra -I. \
+  -DCLIENT_NAME=\"my-ndt7-client\" \
+  -DCLIENT_VERSION=\"v0.1.0\" \
+  -o main main.cpp
 ```
 
 See [codedocs.xyz/measurement-kit/libndt](

--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ int main() {
 }
 ```
 
-Compile with `g++ -std=c++11 -Wall -Wextra -I. -o main main.cpp`.
+Compile your client with a unique name using:
+
+```sh
+g++ -std=c++11 -Wall -Wextra -DCLIENT_NAME=\"my-ndt7-client\" -I. -o main main.cpp
+```
 
 See [codedocs.xyz/measurement-kit/libndt](
 https://codedocs.xyz/measurement-kit/libndt/) for API documentation;
@@ -68,7 +72,7 @@ cmake --build .
 ctest -a --output-on-failure .
 ```
 
-## Command line client 
+## Command line client
 
 Building with CMake also builds a simple command line client. Get usage info
 by running:

--- a/include/libndt/libndt.hpp
+++ b/include/libndt/libndt.hpp
@@ -270,7 +270,7 @@ class Settings {
   std::string port = "443";
 
   /// Scheme to use connecting to the NDT server. If this is not specified, we will use
-  /// the unencrypted configuration.
+  /// the secure websocket configuration.
   std::string scheme = "wss";
 
   /// The tests you want to run with the NDT server. By default we run

--- a/include/libndt/libndt.hpp
+++ b/include/libndt/libndt.hpp
@@ -397,7 +397,7 @@ class Client : public EventHandler {
   // High-level API
   virtual void summary() noexcept;
   virtual bool query_locate_api(const std::map<std::string, std::string>& opts, std::vector<nlohmann::json> *urls) noexcept;
-  virtual std::string get_static_result(std::string opts, std::string scheme, std::string hostname, std::string port);
+  virtual std::string get_static_locate_result(std::string opts, std::string scheme, std::string hostname, std::string port);
   virtual std::string replace_all_with(std::string templ, std::string pattern, std::string replace);
 
   // ndt7 protocol API
@@ -1008,7 +1008,7 @@ void Client::summary() noexcept {
   }
 }
 
-std::string Client::get_static_result(
+std::string Client::get_static_locate_result(
   std::string opts, std::string scheme, std::string hostname, std::string port) {
   std::string templ = R"({
   "results": [
@@ -1049,7 +1049,7 @@ bool Client::query_locate_api(const std::map<std::string, std::string>& opts, st
   if (!settings_.hostname.empty()) {
     LIBNDT_EMIT_DEBUG("no need to query locate api; we have hostname");
     // We already know the hostname, scheme and port, so return a static result.
-    body = get_static_result(
+    body = get_static_locate_result(
       unsafe_format_http_params(opts), settings_.scheme, settings_.hostname,
       settings_.port);
   } else {

--- a/include/libndt/libndt.hpp
+++ b/include/libndt/libndt.hpp
@@ -58,6 +58,10 @@
 #error "Libndt requires nlohmann/json >= 3"
 #endif
 
+#ifndef CLIENT_NAME
+#define CLIENT_NAME "libndt7-default"
+#endif
+
 // TODO(bassosimone): these headers should be in impl.hpp and here we
 // need to include the bare minimum required by the API
 
@@ -285,8 +289,8 @@ class Settings {
   /// the client version and the library.
   std::map<std::string, std::string> metadata{
       {"client_library_version", "v0.1.0"},
-      {"client_library_name", "m-lab/ndt7-client-cc"},
-      // TODO: add build option for specifying client_name.
+      {"client_library_name", "m-lab/libndt7"},
+      {"client_name", CLIENT_NAME}
   };
 
   /// Type of NDT protocol that you want to use. Selecting the protocol may

--- a/include/libndt/libndt.hpp
+++ b/include/libndt/libndt.hpp
@@ -267,7 +267,11 @@ class Settings {
 
   /// Port of the NDT server to use. If this is not specified, we will use
   /// the most correct port depending on the configuration.
-  std::string port;
+  std::string port = "443";
+
+  /// Scheme to use connecting to the NDT server. If this is not specified, we will use
+  /// the unencrypted configuration.
+  std::string scheme = "wss";
 
   /// The tests you want to run with the NDT server. By default we run
   /// a download test, because that is probably the typical usage.
@@ -394,6 +398,8 @@ class Client : public EventHandler {
   // High-level API
   virtual void summary() noexcept;
   virtual bool query_locate_api(const std::map<std::string, std::string>& opts, std::vector<nlohmann::json> *urls) noexcept;
+  virtual std::string get_static_result(std::string opts, std::string scheme, std::string hostname, std::string port);
+  virtual std::string replace_all_with(std::string templ, std::string pattern, std::string replace);
 
   // ndt7 protocol API
   // `````````````````
@@ -1003,27 +1009,60 @@ void Client::summary() noexcept {
   }
 }
 
+std::string Client::get_static_result(
+  std::string opts, std::string scheme, std::string hostname, std::string port) {
+  std::string templ = R"({
+  "results": [
+    {
+      "machine": "{{hostname}}",
+      "location": {
+        "city": "Your City",
+        "country": "US"
+      },
+      "urls": {
+        "{{scheme}}:///ndt/v7/download": "{{scheme}}://{{hostname}}:{{port}}/ndt/v7/download?{{opts}}",
+        "{{scheme}}:///ndt/v7/upload": "{{scheme}}://{{hostname}}:{{port}}/ndt/v7/upload?{{opts}}"
+      }
+    }
+  ]
+})";
+  std::string result = templ;
+  result = replace_all_with(result, "{{hostname}}", hostname);
+  result = replace_all_with(result, "{{scheme}}", scheme);
+  result = replace_all_with(result, "{{port}}", port);
+  result = replace_all_with(result, "{{opts}}", opts);
+  return result;
+}
+
+std::string Client::replace_all_with(std::string templ, std::string pattern, std::string replace) {
+  std::size_t pos = 0;
+  std::string result = templ;
+  while ((pos = result.find(pattern, pos)) != std::string::npos) {
+    result = result.replace(pos, pattern.length(), replace);
+  }
+  return result;
+}
+
 bool Client::query_locate_api(const std::map<std::string, std::string>& opts, std::vector<nlohmann::json> *urls) noexcept {
   assert(urls != nullptr);
-  // TODO(soltesz): support the static host case correctly.
+  std::string body;
+  std::string locate_api_url = settings_.locate_api_base_url;
   if (!settings_.hostname.empty()) {
     LIBNDT_EMIT_DEBUG("no need to query locate api; we have hostname");
-    // When we already know the hostname that we want to use just fake out the
-    // result of a locate_api query as like locate_api returned that hostname.
-    urls->push_back(std::move(settings_.hostname));
-    return true;
-  }
-  std::string locate_api_url = settings_.locate_api_base_url;
-  locate_api_url += "/v2/nearest/ndt/ndt7";
-  if (opts.size() > 0) {
-    // TODO(soltesz): generalize options for country, region, or lat/lon, etc?
-    locate_api_url += "?" + unsafe_format_http_params(opts);
-  }
-  std::string body;
-  LIBNDT_EMIT_INFO("locate_api url: " << locate_api_url);
-  if (!query_locate_api_curl(locate_api_url, settings_.timeout, &body)) {
-
-    return false;
+    // We already know the hostname, scheme and port, so return a static result.
+    body = get_static_result(
+      unsafe_format_http_params(opts), settings_.scheme, settings_.hostname,
+      settings_.port);
+  } else {
+    locate_api_url += "/v2/nearest/ndt/ndt7";
+    if (opts.size() > 0) {
+      // TODO(soltesz): generalize options for country, region, or lat/lon, etc?
+      locate_api_url += "?" + unsafe_format_http_params(opts);
+    }
+    LIBNDT_EMIT_INFO("using locate: " << locate_api_url);
+    if (!query_locate_api_curl(locate_api_url, settings_.timeout, &body)) {
+      return false;
+    }
   }
   LIBNDT_EMIT_DEBUG("locate_api reply: " << body);
   nlohmann::json json;
@@ -1068,7 +1107,7 @@ bool Client::query_locate_api(const std::map<std::string, std::string>& opts, st
 // `````````````````
 
 bool Client::ndt7_download(const UrlParts &url) noexcept {
-  LIBNDT_EMIT_INFO("starting ndt7 download test: " << url.scheme << "://" << url.host);
+  LIBNDT_EMIT_INFO("ndt7: starting download test: " << url.scheme << "://" << url.host);
   if (!ndt7_connect(url)) {
     return false;
   }
@@ -1151,7 +1190,7 @@ bool Client::ndt7_download(const UrlParts &url) noexcept {
 }
 
 bool Client::ndt7_upload(const UrlParts &url) noexcept {
-  LIBNDT_EMIT_INFO("starting ndt7 upload test: " << url.scheme << "://" << url.host);
+  LIBNDT_EMIT_INFO("ndt7: starting upload test: " << url.scheme << "://" << url.host);
   if (!ndt7_connect(url)) {
     return false;
   }

--- a/include/libndt/libndt.hpp
+++ b/include/libndt/libndt.hpp
@@ -2973,7 +2973,7 @@ Verbosity Client::get_verbosity() const noexcept {
 // Function to parse a websocket URL and return its components. The URL must
 // include a resource path.
 // TODO(soltesz): add testing for various input cases.
- UrlParts parse_ws_url(const std::string& url) {
+UrlParts parse_ws_url(const std::string& url) {
   UrlParts parts;
 
   // Find the scheme.

--- a/include/libndt/libndt.hpp
+++ b/include/libndt/libndt.hpp
@@ -59,7 +59,7 @@
 #endif
 
 #ifndef CLIENT_NAME
-#define CLIENT_NAME "libndt7-default"
+#define CLIENT_NAME "libndt7-cc-default"
 #endif
 
 // TODO(bassosimone): these headers should be in impl.hpp and here we

--- a/include/libndt/libndt.hpp
+++ b/include/libndt/libndt.hpp
@@ -58,10 +58,6 @@
 #error "Libndt requires nlohmann/json >= 3"
 #endif
 
-#ifndef CLIENT_NAME
-#define CLIENT_NAME "libndt7-cc-default"
-#endif
-
 // TODO(bassosimone): these headers should be in impl.hpp and here we
 // need to include the bare minimum required by the API
 
@@ -289,8 +285,7 @@ class Settings {
   /// the client version and the library.
   std::map<std::string, std::string> metadata{
       {"client_library_version", "v0.1.0"},
-      {"client_library_name", "m-lab/libndt7"},
-      {"client_name", CLIENT_NAME}
+      {"client_library_name", "m-lab/libndt7-cc"},
   };
 
   /// Type of NDT protocol that you want to use. Selecting the protocol may

--- a/libndt-client.cpp
+++ b/libndt-client.cpp
@@ -21,6 +21,13 @@
 #pragma clang diagnostic pop
 #endif  // __clang__
 
+#ifndef CLIENT_NAME
+#define CLIENT_NAME "libndt7-cc-default"
+#endif
+#ifndef CLIENT_VERSION
+#define CLIENT_VERSION "v0.1.0"
+#endif
+
 using namespace measurement_kit;
 
 // BatchClient only prints JSON messages on stdout.
@@ -216,6 +223,10 @@ int main(int, char **argv) {
       std::clog << "will auto-select a suitable server" << std::endl;
     }
   }
+
+  // Set the client name provided to the Locate API.
+  settings.metadata["client_name"] = CLIENT_NAME;
+  settings.metadata["client_version"] = CLIENT_VERSION;
 
   if (settings.nettest_flags == 0) {
     std::clog << "FATAL: No test selected" << std::endl;

--- a/libndt-client.cpp
+++ b/libndt-client.cpp
@@ -90,10 +90,10 @@ You MUST specify what subtest to enable:
  * `-download` enables the download subtest
  * `-upload` enables the upload subtest
 
-By default, libndt-client uses M-Lab's unregistered Locate API to find a
-suitable target server. For registered clients, you may specify an API key for
-the Locate API using:
-* `-key=<key>`
+By default, libndt-client uses M-Lab's Locate API for unregistered clients
+(without an API key) to find a suitable target server. For registered clients,
+you may specify an API key for the Locate API using:
+* `-locate-api-key=<key>`
 
 Instead of the Locate API, you may specify a specific server using a combination
 of the flags:
@@ -133,7 +133,7 @@ int main(int, char **argv) {
     cmdline.add_param("ca-bundle-path");
     cmdline.add_param("lookup-policy");
     cmdline.add_param("socks5h");
-    cmdline.add_param("key");
+    cmdline.add_param("locate-api-key");
     cmdline.add_param("port");
     cmdline.add_param("scheme");
     cmdline.add_param("hostname");
@@ -174,7 +174,7 @@ int main(int, char **argv) {
       if (param.first == "ca-bundle-path") {
         settings.ca_bundle_path = param.second;
         std::clog << "will use this CA bundle: " << param.second << std::endl;
-      } else if (param.first == "key") {
+      } else if (param.first == "locate-api-key") {
         settings.metadata["key"] = param.second;
         std::clog << "will use this key: " << param.second << std::endl;
       } else if (param.first == "port") {

--- a/libndt-client.cpp
+++ b/libndt-client.cpp
@@ -90,8 +90,13 @@ You MUST specify what subtest to enable:
  * `-download` enables the download subtest
  * `-upload` enables the upload subtest
 
-By default, libndt-client uses M-Lab's Locate API to find a suitable target
-server. You may specify a specific server using a combination of the flags:
+By default, libndt-client uses M-Lab's unregistered Locate API to find a
+suitable target server. For registered clients, you may specify an API key for
+the Locate API using:
+* `-key=<key>`
+
+Instead of the Locate API, you may specify a specific server using a combination
+of the flags:
  * `-port=<port>`
  * `-scheme=<ws>`
  * `-hostname=<hostname>`
@@ -104,15 +109,12 @@ The default mode is wss (TLS).
 You may control information output using a combination of the following flags:
  * `-batch` outputs JSON results to STDOUT.
  * `-summary` only prints a summary at the end of the test.
+ * `-verbose` prints additional debug information.
 
 In combination, -batch and -summary produce a final summary in JSON.
 
-
-When running, this client emits messages. You can use `-verbose` to cause
-it to emit even more messages.
-
 The `-socks5h <port>` flag causes this tool to use the specified SOCKS5h
-proxy to contact mlab-ns and for running the selected subtests.
+proxy to contact Locate API and for running the selected subtests.
 
 The `-version` shows the version number and exits.)" << std::endl;
   // clang-format on
@@ -131,6 +133,7 @@ int main(int, char **argv) {
     cmdline.add_param("ca-bundle-path");
     cmdline.add_param("lookup-policy");
     cmdline.add_param("socks5h");
+    cmdline.add_param("key");
     cmdline.add_param("port");
     cmdline.add_param("scheme");
     cmdline.add_param("hostname");
@@ -171,6 +174,9 @@ int main(int, char **argv) {
       if (param.first == "ca-bundle-path") {
         settings.ca_bundle_path = param.second;
         std::clog << "will use this CA bundle: " << param.second << std::endl;
+      } else if (param.first == "key") {
+        settings.metadata["key"] = param.second;
+        std::clog << "will use this key: " << param.second << std::endl;
       } else if (param.first == "port") {
         settings.port = param.second;
         std::clog << "will use this port: " << param.second << std::endl;

--- a/libndt-client.cpp
+++ b/libndt-client.cpp
@@ -84,44 +84,29 @@ void BatchClient::summary() noexcept {
 
 static void usage() {
   // clang-format off
-  std::clog << R"(Usage: libndt-client [options] [<hostname>]
+  std::clog << R"(Usage: libndt-client <-upload|-download> [options]
 
-Options can start either with a single dash (i.e. -option) or with
-a double dash (i.e. --option).
+You MUST specify what subtest to enable:
+ * `-download` enables the download subtest
+ * `-upload` enables the upload subtest
 
-If an hostname is not specified, we use M-Lab's name service to
-lookup a suitable M-Lab server to run the test with. You can use
-the `-lookup-policy <policy>` flag to choose the policy to discover
-M-Lab servers. The available policies are: `closest`, `random`,
-and `geo-options`. The `closest` policy requests the hostname of a
-closest nearby server. The `random` policy requests the hostname
-of a random server. The `geo-options` policy returns a list of
-nearby servers. The default policy is `geo-options`. The deprecated
-`-random` flag is an alias for `-lookup-policy random`.
+By default, libndt-client uses M-Lab's Locate API to find a suitable target
+server. You may specify a specific server using a combination of the flags:
+ * `-port=<port>`
+ * `-scheme=<ws>`
+ * `-hostname=<hostname>`
 
-You MUST specify what subtest to enable. The `-download` flag enables the
-download subtest. The `-upload` flag enables the upload subtest.
+The default mode is wss (TLS).
+ * `-scheme=wss` (default)
+ * `-insecure` allows connecting to servers with self-signed or invalid certs.
+ * `-ca-bundle-path=<path>` allows specifying an alternate CA bundle.
 
-The `-port <port>` flag specifies what port to use. The default is to
-use the correct port depending on the selected NDT protocol (see below).
+You may control information output using a combination of the following flags:
+ * `-batch` outputs JSON results to STDOUT.
+ * `-summary` only prints a summary at the end of the test.
 
-By default, we use the ndt7 protocol. Adding the `-tls` flag causes NDT to use
-a TLS connection rather than a TCP connection. When using `-tls`, you may also
-want to use `-insecure` to allow connecting to servers with self-signed or
-otherwise invalid TLS certificate. With `-tls`, you can also use the
-`-ca-bundle-path <path>` to use a specific CA bundle path. Adding the
-`-websocket` flag will cause NDT to wrap its messages (possibly already wrapped
-by JSON) into WebSocket messages. Also, `-batch` can be specified so that the
-only output on STDOUT will be the JSON test results.  To further reduce the
-amount of output, you can use the `-summary` flag, which only prints a summary
-at the end of the tests. If used with `-batch`, the generated summary will be
-JSON.
+In combination, -batch and -summary produce a final summary in JSON.
 
-In practice, these are the flags you want to use for ndt7:
-
-1. none, to use the plain ndt7 protocol (ws://);
-
-2. `-tls` to use the ndt7 protocol over TLS (wss://);
 
 When running, this client emits messages. You can use `-verbose` to cause
 it to emit even more messages.
@@ -145,25 +130,24 @@ int main(int, char **argv) {
     argh::parser cmdline;
     cmdline.add_param("ca-bundle-path");
     cmdline.add_param("lookup-policy");
-    cmdline.add_param("port");
     cmdline.add_param("socks5h");
+    cmdline.add_param("port");
+    cmdline.add_param("scheme");
+    cmdline.add_param("hostname");
     cmdline.parse(argv);
     for (auto &flag : cmdline.flags()) {
       if (flag == "download") {
         settings.nettest_flags |= libndt::nettest_flag_download;
         std::clog << "will run the download sub-test" << std::endl;
+      } else if (flag == "upload") {
+        settings.nettest_flags |= libndt::nettest_flag_upload;
+        std::clog << "will run the upload sub-test" << std::endl;
       } else if (flag == "help") {
         usage();
         exit(EXIT_SUCCESS);
       } else if (flag == "insecure") {
         settings.tls_verify_peer = false;
         std::clog << "WILL NOT verify the TLS peer (INSECURE!)" << std::endl;
-      } else if (flag == "tls") {
-        settings.protocol_flags |= libndt::protocol_flag_tls;
-        std::clog << "will secure communications using TLS" << std::endl;
-      } else if (flag == "upload") {
-        settings.nettest_flags |= libndt::nettest_flag_upload;
-        std::clog << "will run the upload sub-test" << std::endl;
       } else if (flag == "verbose") {
         settings.verbosity = libndt::verbosity_debug;
         std::clog << "will be verbose" << std::endl;
@@ -190,6 +174,12 @@ int main(int, char **argv) {
       } else if (param.first == "port") {
         settings.port = param.second;
         std::clog << "will use this port: " << param.second << std::endl;
+      } else if (param.first == "scheme") {
+        settings.scheme = param.second;
+        std::clog << "will use this scheme: " << param.second << std::endl;
+      } else if (param.first == "hostname") {
+        settings.hostname = param.second;
+        std::clog << "will use this hostname: " << param.second << std::endl;
       } else if (param.first == "socks5h") {
         settings.socks5h_port = param.second;
         std::clog << "will use the socks5h proxy at: 127.0.0.1:" << param.second << std::endl;
@@ -199,14 +189,23 @@ int main(int, char **argv) {
         exit(EXIT_FAILURE);
       }
     }
+    if (settings.scheme != "ws" && settings.scheme != "wss" ) {
+      std::clog << "fatal: invalid scheme: " << settings.scheme << std::endl;
+      usage();
+      exit(EXIT_FAILURE);
+    }
+    if (settings.scheme == "wss") {
+      settings.protocol_flags |= libndt::protocol_flag_tls;
+      std::clog << "will secure communications using TLS" << std::endl;
+    }
     auto sz = cmdline.pos_args().size();
     if (sz != 1 && sz != 2) {
       usage();
       exit(EXIT_FAILURE);
     }
-    if (sz == 2) {
-      settings.hostname = cmdline.pos_args()[1];
-      std::clog << "will use this NDT server: " << cmdline.pos_args()[1] << std::endl;
+    if (!settings.hostname.empty()) {
+      std::clog << "will use this static NDT server: " << \
+        settings.scheme << "://" << settings.hostname << ":" << settings.port << std::endl;
     } else {
       std::clog << "will auto-select a suitable server" << std::endl;
     }


### PR DESCRIPTION
This change adds new functionality to the library and libndt-client.

libndt-client:
* adds several new flags
   * `-key` provides an optional API key for the Locate API
   * `-hostname` is now explicit flag, required for static targets
   *  `-scheme` defaults to "wss" and can be set to "ws".
* help text is significantly revised

libndt:
* wss scheme is the default
* complete support for static targets
* CLIENT_NAME can be set at build time

```sh
$ ./libndt-client -scheme ws -hostname=localhost -port 80 -upload
will run the upload sub-test
will use this hostname: localhost
will use this port: 80
will use this scheme: ws
will use this static NDT server: ws://localhost:80
ndt7: starting upload test: ws://localhost
  [ 3%] speed:   20.6 Gbit/s
  [ 5%] speed:     21 Gbit/s
  [ 8%] speed:   21.1 Gbit/s
  [10%] speed:     21 Gbit/s
  ...
ndt7: test complete
[Test results]
Upload speed:     21 Gbit/s
```

Part of:
* https://github.com/m-lab/ndt7-client-cc/issues/2

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-cc/6)
<!-- Reviewable:end -->
