### PR TITLE
fix(locate): Add new flag -locate-api-url=

### DIFF
--- a/include/libndt7/libndt7.hpp
+++ b/include/libndt7/libndt7.hpp
@@ -1055,7 +1055,7 @@ bool Client::query_locate_api(const std::map<std::string, std::string>& opts, st
       format_http_params(opts), settings_.scheme, settings_.hostname,
       settings_.port);
   } else {
-    if (settings_.metadata.count("key")){
+    if (opts.count("key")){
       locate_api_url += "/v2/priority/nearest/ndt/ndt7";
     } else {
       locate_api_url += "/v2/nearest/ndt/ndt7";

--- a/include/libndt7/libndt7.hpp
+++ b/include/libndt7/libndt7.hpp
@@ -1055,7 +1055,11 @@ bool Client::query_locate_api(const std::map<std::string, std::string>& opts, st
       format_http_params(opts), settings_.scheme, settings_.hostname,
       settings_.port);
   } else {
-    locate_api_url += "/v2/nearest/ndt/ndt7";
+    if (settings_.metadata.count("key")){
+      locate_api_url += "/v2/priority/nearest/ndt/ndt7";
+    } else {
+      locate_api_url += "/v2/nearest/ndt/ndt7";
+    }
     if (opts.size() > 0) {
       // TODO(soltesz): generalize options for country, region, or lat/lon, etc?
       locate_api_url += "?" + format_http_params(opts);

--- a/ndt7-client-cc.cpp
+++ b/ndt7-client-cc.cpp
@@ -101,7 +101,7 @@ By default, ndt7-client-cc uses M-Lab's Locate API for unregistered clients
 (without an API key) to find a suitable target server. For registered clients,
 you may specify an API key for the Locate API using:
 * `-locate-api-key=<key>`
-* `-locate-url=<url>`
+* `-locate-api-url=<url>`
 
 Instead of the Locate API, you may specify a specific server using a combination
 of the flags:
@@ -142,7 +142,7 @@ int main(int, char **argv) {
     cmdline.add_param("lookup-policy");
     cmdline.add_param("socks5h");
     cmdline.add_param("locate-api-key");
-    cmdline.add_param("locate-url");
+    cmdline.add_param("locate-api-url");
     cmdline.add_param("port");
     cmdline.add_param("scheme");
     cmdline.add_param("hostname");
@@ -185,10 +185,10 @@ int main(int, char **argv) {
         std::clog << "will use this CA bundle: " << param.second << std::endl;
       } else if (param.first == "locate-api-key") {
         settings.metadata["key"] = param.second;
-        std::clog << "will use this key: " << param.second << std::endl;
-      } else if (param.first == "locate-url") {
+        std::clog << "will use this locate api key: " << param.second << std::endl;
+      } else if (param.first == "locate-api-url") {
         settings.locate_api_base_url = param.second;
-        std::clog << "will use this locate url: " << param.second << std::endl;
+        std::clog << "will use this locate api url: " << param.second << std::endl;
       } else if (param.first == "port") {
         settings.port = param.second;
         std::clog << "will use this port: " << param.second << std::endl;

--- a/ndt7-client-cc.cpp
+++ b/ndt7-client-cc.cpp
@@ -101,6 +101,7 @@ By default, ndt7-client-cc uses M-Lab's Locate API for unregistered clients
 (without an API key) to find a suitable target server. For registered clients,
 you may specify an API key for the Locate API using:
 * `-locate-api-key=<key>`
+* `-locate-url=<url>`
 
 Instead of the Locate API, you may specify a specific server using a combination
 of the flags:
@@ -141,6 +142,7 @@ int main(int, char **argv) {
     cmdline.add_param("lookup-policy");
     cmdline.add_param("socks5h");
     cmdline.add_param("locate-api-key");
+    cmdline.add_param("locate-url");
     cmdline.add_param("port");
     cmdline.add_param("scheme");
     cmdline.add_param("hostname");
@@ -184,6 +186,9 @@ int main(int, char **argv) {
       } else if (param.first == "locate-api-key") {
         settings.metadata["key"] = param.second;
         std::clog << "will use this key: " << param.second << std::endl;
+      } else if (param.first == "locate-url") {
+        settings.locate_api_base_url = param.second;
+        std::clog << "will use this locate url: " << param.second << std::endl;
       } else if (param.first == "port") {
         settings.port = param.second;
         std::clog << "will use this port: " << param.second << std::endl;


### PR DESCRIPTION
This change correctly applies the locate-api-key (when given) to the `/v2/priority/*` resource. This change also adds a new flag to specify an alternate `-locate-api-url=`, which is helpful for testing.

Part of:
* https://github.com/m-lab/ndt7-client-cc/issues/2

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-cc/12)
<!-- Reviewable:end -->
