### PR TITLE
Update parse_ws_urls to recognize IPv6 addresses in urls

### DIFF
--- a/include/libndt7/libndt7.hpp
+++ b/include/libndt7/libndt7.hpp
@@ -2981,10 +2981,7 @@ Verbosity Client::get_verbosity() const noexcept {
   return settings_.verbosity;
 }
 
-// Function to parse a websocket URL and return its components. The URL should
-// include a resource path.
-UrlParts parse_ws_url(const std::string& url) {
-    std::regex url_regex(
+const std::regex url_regex(
       "^([^:/]+)"              // scheme (group 1)
       "://"                    // constant URI string
          "("                   // hostname (group 2)
@@ -2995,6 +2992,10 @@ UrlParts parse_ws_url(const std::string& url) {
       "(?::(\\d+))?"           // port, if present (group 3)
       "(/.*)?"                 // path and query, if present (group 4)
     );
+
+// Function to parse a websocket URL and return its components. The URL should
+// include a resource path.
+UrlParts parse_ws_url(const std::string& url) {
     std::smatch match;
     UrlParts parts;
 

--- a/single_include/libndt7.hpp
+++ b/single_include/libndt7.hpp
@@ -21726,12 +21726,12 @@ using Timeout = unsigned int;
 #include <random>
 
 // TODO(github.com/m-lab/ndt7-client-cc/issues/10): Remove pragma ignoring warning when possible.
-#ifndef __clang__
+#if !defined(__clang__) && defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 #include <regex>
-#ifndef __clang__
+#if !defined(__clang__) && defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
 #include <sstream>
@@ -24610,10 +24610,7 @@ Verbosity Client::get_verbosity() const noexcept {
   return settings_.verbosity;
 }
 
-// Function to parse a websocket URL and return its components. The URL should
-// include a resource path.
-UrlParts parse_ws_url(const std::string& url) {
-    std::regex url_regex(
+const std::regex url_regex(
       "^([^:/]+)"              // scheme (group 1)
       "://"                    // constant URI string
          "("                   // hostname (group 2)
@@ -24624,6 +24621,10 @@ UrlParts parse_ws_url(const std::string& url) {
       "(?::(\\d+))?"           // port, if present (group 3)
       "(/.*)?"                 // path and query, if present (group 4)
     );
+
+// Function to parse a websocket URL and return its components. The URL should
+// include a resource path.
+UrlParts parse_ws_url(const std::string& url) {
     std::smatch match;
     UrlParts parts;
 

--- a/single_include/libndt7.hpp
+++ b/single_include/libndt7.hpp
@@ -21724,6 +21724,16 @@ using Timeout = unsigned int;
 #include <memory>
 #include <mutex>
 #include <random>
+
+// TODO(github.com/m-lab/ndt7-client-cc/issues/10): Remove pragma ignoring warning when possible.
+#ifndef __clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+#include <regex>
+#ifndef __clang__
+#pragma GCC diagnostic pop
+#endif
 #include <sstream>
 #include <string>
 #include <thread>
@@ -24600,45 +24610,40 @@ Verbosity Client::get_verbosity() const noexcept {
   return settings_.verbosity;
 }
 
-// Function to parse a websocket URL and return its components. The URL must
+// Function to parse a websocket URL and return its components. The URL should
 // include a resource path.
-// TODO(soltesz): add testing for various input cases.
 UrlParts parse_ws_url(const std::string& url) {
-  UrlParts parts;
+    std::regex url_regex(
+      "^([^:/]+)"              // scheme (group 1)
+      "://"                    // constant URI string
+         "("                   // hostname (group 2)
+           "(?:[^/:]*)"        //   standard hostname, may be empty
+           "|"                 //   OR
+           "(?:\\[[^\\]]+\\])" //   everything between two [] brackets, e.g. ipv6.
+         ")"                   //
+      "(?::(\\d+))?"           // port, if present (group 3)
+      "(/.*)?"                 // path and query, if present (group 4)
+    );
+    std::smatch match;
+    UrlParts parts;
 
-  // Find the scheme.
-  auto colon_pos = url.find(":");
-  if (colon_pos != std::string::npos) {
-    parts.scheme = url.substr(0, colon_pos);
-  }
-
-  // Extract the hostname and port.
-  auto slash_pos = url.find("/", colon_pos + 3);
-  if (slash_pos == std::string::npos) {
-    // No resource path.
-    slash_pos = url.length();
-  }
-  auto host_part = url.substr(colon_pos + 3, slash_pos - colon_pos - 3);
-  auto port_pos = host_part.find(":");
-  // Does the host include a port?
-  if (port_pos != std::string::npos) {
-    parts.host = host_part.substr(0, port_pos);
-    parts.port = host_part.substr(port_pos + 1);
-  } else {
-    parts.host = host_part;
-    if (parts.scheme == "ws") {
-      parts.port = "80";
-    } else if (parts.scheme == "wss") {
-      parts.port = "443";
+    if (!std::regex_match(url, match, url_regex)) {
+      // Failed to match return empty parts.
+      return parts;
     }
-  }
-
-  // Extract the path.
-  if (slash_pos != std::string::npos) {
-    parts.path = url.substr(slash_pos);
-  }
-
-  return parts;
+    parts.scheme = match[1].str();
+    parts.host = match[2].str();
+    parts.port = match[3].str(); // Empty if not present
+    parts.path = match[4].str(); // Includes query
+    std::cout << match[5].str(); // Includes query
+    if (parts.port.empty()) {
+      if (parts.scheme == "ws" || parts.scheme == "http") {
+        parts.port = "80";
+      } else if (parts.scheme == "wss" || parts.scheme == "https") {
+        parts.port = "443";
+      }
+    }
+    return parts;
 }
 
 static std::string curl_urlencode(const std::string& raw) {

--- a/test/curlx_test.cpp
+++ b/test/curlx_test.cpp
@@ -6,12 +6,12 @@
 
 #define CATCH_CONFIG_MAIN
 // TODO(github.com/m-lab/ndt7-client-cc/issues/10): Remove pragma ignoring warning when possible.
-#ifndef __clang__
+#if !defined(__clang__) && defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 #include "third_party/github.com/catchorg/Catch2/catch.hpp"
-#ifndef __clang__
+#if !defined(__clang__) && defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/test/libndt7_test.cpp
+++ b/test/libndt7_test.cpp
@@ -25,12 +25,12 @@
 
 #define CATCH_CONFIG_MAIN
 // TODO(github.com/m-lab/ndt7-client-cc/issues/10): Remove pragma ignoring warning when possible.
-#ifndef __clang__
+#if !defined(__clang__) && defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 #include "third_party/github.com/catchorg/Catch2/catch.hpp"
-#ifndef __clang__
+#if !defined(__clang__) && defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
 
@@ -83,13 +83,14 @@ TEST_CASE("Client::parse_ws_url() table tests") {
       .url = "://",
       .want = {.scheme = "", .host = "", .port = "", .path = ""},
     },
-    /*
-    TODO(soltesz): support parsing IPv6 hosts.
     {
-      .url = "ws://[::1]/test?foo",
-      .want = {.scheme = "ws", .host = "[::1]", .port = "80", .path = "/test?foo"},
+      .url = "ws://127.0.0.1:8888/test?foo",
+      .want = {.scheme = "ws", .host = "127.0.0.1", .port = "8888", .path = "/test?foo"},
     },
-    */
+    {
+      .url = "wss://[abc::1]/test?foo&x=1",
+      .want = {.scheme = "wss", .host = "[abc::1]", .port = "443", .path = "/test?foo&x=1"},
+    },
   };
   for (unsigned long i = 0; i < sizeof(cases)/sizeof(cases[0]); i++ ) {
     auto parts = parse_ws_url(cases[i].url);

--- a/test/sys_test.cpp
+++ b/test/sys_test.cpp
@@ -8,12 +8,12 @@
 
 #define CATCH_CONFIG_MAIN
 // TODO(github.com/m-lab/ndt7-client-cc/issues/10): Remove pragma ignoring warning when possible.
-#ifndef __clang__
+#if !defined(__clang__) && defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 #include "third_party/github.com/catchorg/Catch2/catch.hpp"
-#ifndef __clang__
+#if !defined(__clang__) && defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
This change resolves an open TODO to allow `parse_ws_url` to recognize URLs with literal IPv6 addresses. To support this, the parse_ws_url function now uses `<regex>` to parse the fields within the URL.

Part of:
* https://github.com/m-lab/ndt7-client-cc/issues/2