### PR TITLE
fix(typo): remove double seven from library rename

### DIFF
--- a/include/libndt7/preamble.hpp
+++ b/include/libndt7/preamble.hpp
@@ -3,8 +3,8 @@
 
 // libndt7/preamble.hpp - preamble for single include header
 
-#ifndef LIBNDT77_SINGLE_INCLUDE
-#define LIBNDT77_SINGLE_INCLUDE 1
+#ifndef LIBNDT7_SINGLE_INCLUDE
+#define LIBNDT7_SINGLE_INCLUDE 1
 #endif
 
 #endif  // MEASUREMENTLAB_LIBNDT7_PREAMBLE_HPP

--- a/single_include/libndt7.hpp
+++ b/single_include/libndt7.hpp
@@ -3,8 +3,8 @@
 
 // libndt7/preamble.hpp - preamble for single include header
 
-#ifndef LIBNDT77_SINGLE_INCLUDE
-#define LIBNDT77_SINGLE_INCLUDE 1
+#ifndef LIBNDT7_SINGLE_INCLUDE
+#define LIBNDT7_SINGLE_INCLUDE 1
 #endif
 
 #endif  // MEASUREMENTLAB_LIBNDT7_PREAMBLE_HPP


### PR DESCRIPTION
This change fixes a typo remaining from the library renaming.

Fixes: https://github.com/m-lab/ndt7-client-cc/issues/20

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-cc/22)
<!-- Reviewable:end -->
