### PR TITLE
fix: retry servers fully and update docstring for run

### DIFF
--- a/include/libndt7/libndt7.hpp
+++ b/include/libndt7/libndt7.hpp
@@ -13,17 +13,13 @@
 /// advanced usage may require you to create a subclass of `libndt7::Client` and
 /// override specific virtual methods to customize the behaviour.
 ///
-/// This implementation provides the C2S and S2C NDT subtests. We implement
-/// NDT over TLS and NDT over websocket. For more information on the NDT
-/// protocol, \see https://github.com/ndt-project/ndt/wiki/NDTProtocol.
+/// This implementation provides version 7 of the NDT protocol (aka ndt7). The
+/// code in this library includes C2S (upload) and S2C (download) ndt7 subtests
+/// based on the ndt7 specification, which is described at \see
+/// https://github.com/m-lab/ndt-server/blob/master/spec/ndt7-protocol.md.
 ///
-/// The NDT protocol described above is version 5 (aka ndt5). The code in this
-/// library also implements the ndt7 specification, which is described at
-/// \see https://github.com/m-lab/ndt-server/blob/master/spec/ndt7-protocol.md.
-///
-/// Throughout this file, we'll use NDT to indicate ndt5 and ndt7 explicitly
-/// to indicate version 7 of the protocol. Please, use ndt7 in newer code and
-/// stick to ndt5 only if backwards compatibility is necessary.
+/// Throughout this file, we'll use NDT or ndt7 interchangably to indicate
+/// version 7 of the protocol.
 ///
 /// \remark As a general rule, what is not documented using Doxygen comments
 /// inside of this file is considered either internal or experimental. We
@@ -219,19 +215,18 @@ class EventHandler {
                               double measured_bytes, double elapsed,
                               double max_runtime) noexcept = 0;
 
-  /// Called to provide you with NDT results. The default behavior is
-  /// to write the provided information as an info message. @param scope is
-  /// "web100", when we're passing you Web 100 variables, "tcp_info" when
-  /// we're passing you TCP info variables, "summary" when we're passing you
-  /// summary variables, or "ndt7" when we're passing you results returned
-  /// by a ndt7 server. @param name is the name of the variable; if @p scope
-  /// is "ndt7", then @p name should be "download". @param value is the
-  /// variable value; variables are typically int, float, or string when
-  /// running ndt5 tests, instead they are serialized JSON returned by the
-  /// server when running a ndt7 test. \warning This method could be called
-  /// from another thread context.
-  virtual void on_result(std::string scope, std::string name,
-                         std::string value) noexcept = 0;
+  /// Called to provide you with NDT results. The default behavior is to write
+  /// the provided information as an info message. @param scope is "tcp_info"
+  /// when we're passing you TCP info variables, "summary" when we're passing
+  /// you summary variables, or "ndt7" when we're passing you results returned
+  /// by a ndt7 server. @param name is the name of the variable; if @p scope is
+  /// "ndt7", then @p name should be "download". @param value is the variable
+  /// value; variables are typically int, float, or string when running ndt5
+  /// tests, instead they are serialized JSON returned by the server when
+  /// running a ndt7 test. \warning This method could be called from another
+  /// thread context.
+  virtual void on_result(std::string scope, std::string name, std::string value)
+  noexcept = 0;
 
   /// Called when the server is busy. The default behavior is to write a
   /// warning message. @param msg is the reason why the server is busy, encoded
@@ -356,7 +351,10 @@ class Client : public EventHandler {
   /// Destroys a Client.
   virtual ~Client() noexcept;
 
-  /// Runs a NDT test using the configured (or default) settings.
+  /// Runs an ndt7 test based on the configured settings. On success, `run`
+  /// returns true. When using the Locate API, `run` will attempt a test with
+  /// multiple servers, stopping on the first success or continue trying the
+  /// next server on failure. If all attempts fail, `run` returns false.
   bool run() noexcept;
 
   void on_warning(const std::string &s) const noexcept override;
@@ -601,9 +599,6 @@ class Client : public EventHandler {
   };
 
   SummaryData summary_;
-
-  // NDT web100 summary data.
-  nlohmann::json web100;
 
   // ndt7 Measurement object.
   nlohmann::json measurement_;
@@ -904,9 +899,10 @@ bool Client::run() noexcept {
   if ((settings_.protocol_flags & protocol_flag_tls) != 0) {
     scheme = "wss";
   }
-  for (auto &urls : targets) {
-    LIBNDT7_EMIT_DEBUG("using the ndt7 protocol");
-    if ((settings_.nettest_flags & nettest_flag_download) != 0) {
+  bool success = true;
+  LIBNDT7_EMIT_DEBUG("using the ndt7 protocol");
+  if ((settings_.nettest_flags & nettest_flag_download) != 0) {
+    for (auto &urls : targets) {
       auto key = scheme + ":///ndt/v7/download";
       if (!urls.contains(key)) {
         LIBNDT7_EMIT_WARNING("ndt7: scheme not found in results: " << scheme);
@@ -914,12 +910,22 @@ bool Client::run() noexcept {
       }
       auto url = urls[key];
       UrlParts parts = parse_ws_url(url);
-      if (!ndt7_download(parts)) {
+      success = ndt7_download(parts);
+      if (!success) {
         LIBNDT7_EMIT_WARNING("ndt7: download failed");
-       // FALLTHROUGH
+        // try next server.
+        continue;
       }
+      // download succeeded.
+      break;
     }
-    if ((settings_.nettest_flags & nettest_flag_upload) != 0) {
+  }
+  if (!success) {
+    LIBNDT7_EMIT_WARNING("no more hosts to try; failing the test");
+    return false;
+  }
+  if ((settings_.nettest_flags & nettest_flag_upload) != 0) {
+    for (auto &urls : targets) {
       auto key = scheme + ":///ndt/v7/upload";
       if (!urls.contains(key)) {
         LIBNDT7_EMIT_WARNING("ndt7: scheme not found in results: " << scheme);
@@ -927,16 +933,22 @@ bool Client::run() noexcept {
       }
       auto url = urls[key];
       UrlParts parts = parse_ws_url(url);
-      if (!ndt7_upload(parts)) {
+      success = ndt7_upload(parts);
+      if (!success) {
         LIBNDT7_EMIT_WARNING("ndt7: upload failed");
-        // FALLTHROUGH
+        // Try next server.
+        continue;
       }
+      // upload succeeded.
+      break;
     }
-    LIBNDT7_EMIT_INFO("ndt7: test complete");
-    return true;
   }
-  LIBNDT7_EMIT_WARNING("no more hosts to try; failing the test");
-  return false;
+  if (success) {
+    LIBNDT7_EMIT_INFO("ndt7: test complete");
+  } else {
+    LIBNDT7_EMIT_WARNING("no more hosts to try; failing the test");
+  }
+  return success;
 }
 
 void Client::on_warning(const std::string &msg) const noexcept {
@@ -1004,9 +1016,6 @@ void Client::summary() noexcept {
       LIBNDT7_EMIT_INFO("Upload retransmission: "
         << std::fixed << std::setprecision(2)
         << (summary_.upload_retrans * 100) << "%");
-  }
-  if (web100 != nullptr) {
-    LIBNDT7_EMIT_DEBUG("web100: " << web100.dump());
   }
 }
 

--- a/ndt7-client-cc.cpp
+++ b/ndt7-client-cc.cpp
@@ -66,10 +66,6 @@ void BatchClient::summary() noexcept {
     download["Speed"] = summary_.download_speed;
     download["Retransmission"] = summary_.download_retrans;
 
-    if (web100 != nullptr) {
-      download["Web100"] = web100;
-    }
-
     if (measurement_ != nullptr) {
       download["ConnectionInfo"] = connection_info_;
       download["LastMeasurement"] = measurement_;

--- a/single_include/libndt7.hpp
+++ b/single_include/libndt7.hpp
@@ -21642,17 +21642,13 @@ using Timeout = unsigned int;
 /// advanced usage may require you to create a subclass of `libndt7::Client` and
 /// override specific virtual methods to customize the behaviour.
 ///
-/// This implementation provides the C2S and S2C NDT subtests. We implement
-/// NDT over TLS and NDT over websocket. For more information on the NDT
-/// protocol, \see https://github.com/ndt-project/ndt/wiki/NDTProtocol.
+/// This implementation provides version 7 of the NDT protocol (aka ndt7). The
+/// code in this library includes C2S (upload) and S2C (download) ndt7 subtests
+/// based on the ndt7 specification, which is described at \see
+/// https://github.com/m-lab/ndt-server/blob/master/spec/ndt7-protocol.md.
 ///
-/// The NDT protocol described above is version 5 (aka ndt5). The code in this
-/// library also implements the ndt7 specification, which is described at
-/// \see https://github.com/m-lab/ndt-server/blob/master/spec/ndt7-protocol.md.
-///
-/// Throughout this file, we'll use NDT to indicate ndt5 and ndt7 explicitly
-/// to indicate version 7 of the protocol. Please, use ndt7 in newer code and
-/// stick to ndt5 only if backwards compatibility is necessary.
+/// Throughout this file, we'll use NDT or ndt7 interchangably to indicate
+/// version 7 of the protocol.
 ///
 /// \remark As a general rule, what is not documented using Doxygen comments
 /// inside of this file is considered either internal or experimental. We
@@ -21848,19 +21844,18 @@ class EventHandler {
                               double measured_bytes, double elapsed,
                               double max_runtime) noexcept = 0;
 
-  /// Called to provide you with NDT results. The default behavior is
-  /// to write the provided information as an info message. @param scope is
-  /// "web100", when we're passing you Web 100 variables, "tcp_info" when
-  /// we're passing you TCP info variables, "summary" when we're passing you
-  /// summary variables, or "ndt7" when we're passing you results returned
-  /// by a ndt7 server. @param name is the name of the variable; if @p scope
-  /// is "ndt7", then @p name should be "download". @param value is the
-  /// variable value; variables are typically int, float, or string when
-  /// running ndt5 tests, instead they are serialized JSON returned by the
-  /// server when running a ndt7 test. \warning This method could be called
-  /// from another thread context.
-  virtual void on_result(std::string scope, std::string name,
-                         std::string value) noexcept = 0;
+  /// Called to provide you with NDT results. The default behavior is to write
+  /// the provided information as an info message. @param scope is "tcp_info"
+  /// when we're passing you TCP info variables, "summary" when we're passing
+  /// you summary variables, or "ndt7" when we're passing you results returned
+  /// by a ndt7 server. @param name is the name of the variable; if @p scope is
+  /// "ndt7", then @p name should be "download". @param value is the variable
+  /// value; variables are typically int, float, or string when running ndt5
+  /// tests, instead they are serialized JSON returned by the server when
+  /// running a ndt7 test. \warning This method could be called from another
+  /// thread context.
+  virtual void on_result(std::string scope, std::string name, std::string value)
+  noexcept = 0;
 
   /// Called when the server is busy. The default behavior is to write a
   /// warning message. @param msg is the reason why the server is busy, encoded
@@ -21985,7 +21980,10 @@ class Client : public EventHandler {
   /// Destroys a Client.
   virtual ~Client() noexcept;
 
-  /// Runs a NDT test using the configured (or default) settings.
+  /// Runs an ndt7 test based on the configured settings. On success, `run`
+  /// returns true. When using the Locate API, `run` will attempt a test with
+  /// multiple servers, stopping on the first success or continue trying the
+  /// next server on failure. If all attempts fail, `run` returns false.
   bool run() noexcept;
 
   void on_warning(const std::string &s) const noexcept override;
@@ -22230,9 +22228,6 @@ class Client : public EventHandler {
   };
 
   SummaryData summary_;
-
-  // NDT web100 summary data.
-  nlohmann::json web100;
 
   // ndt7 Measurement object.
   nlohmann::json measurement_;
@@ -22533,9 +22528,10 @@ bool Client::run() noexcept {
   if ((settings_.protocol_flags & protocol_flag_tls) != 0) {
     scheme = "wss";
   }
-  for (auto &urls : targets) {
-    LIBNDT7_EMIT_DEBUG("using the ndt7 protocol");
-    if ((settings_.nettest_flags & nettest_flag_download) != 0) {
+  bool success = true;
+  LIBNDT7_EMIT_DEBUG("using the ndt7 protocol");
+  if ((settings_.nettest_flags & nettest_flag_download) != 0) {
+    for (auto &urls : targets) {
       auto key = scheme + ":///ndt/v7/download";
       if (!urls.contains(key)) {
         LIBNDT7_EMIT_WARNING("ndt7: scheme not found in results: " << scheme);
@@ -22543,12 +22539,22 @@ bool Client::run() noexcept {
       }
       auto url = urls[key];
       UrlParts parts = parse_ws_url(url);
-      if (!ndt7_download(parts)) {
+      success = ndt7_download(parts);
+      if (!success) {
         LIBNDT7_EMIT_WARNING("ndt7: download failed");
-       // FALLTHROUGH
+        // try next server.
+        continue;
       }
+      // download succeeded.
+      break;
     }
-    if ((settings_.nettest_flags & nettest_flag_upload) != 0) {
+  }
+  if (!success) {
+    LIBNDT7_EMIT_WARNING("no more hosts to try; failing the test");
+    return false;
+  }
+  if ((settings_.nettest_flags & nettest_flag_upload) != 0) {
+    for (auto &urls : targets) {
       auto key = scheme + ":///ndt/v7/upload";
       if (!urls.contains(key)) {
         LIBNDT7_EMIT_WARNING("ndt7: scheme not found in results: " << scheme);
@@ -22556,16 +22562,22 @@ bool Client::run() noexcept {
       }
       auto url = urls[key];
       UrlParts parts = parse_ws_url(url);
-      if (!ndt7_upload(parts)) {
+      success = ndt7_upload(parts);
+      if (!success) {
         LIBNDT7_EMIT_WARNING("ndt7: upload failed");
-        // FALLTHROUGH
+        // Try next server.
+        continue;
       }
+      // upload succeeded.
+      break;
     }
-    LIBNDT7_EMIT_INFO("ndt7: test complete");
-    return true;
   }
-  LIBNDT7_EMIT_WARNING("no more hosts to try; failing the test");
-  return false;
+  if (success) {
+    LIBNDT7_EMIT_INFO("ndt7: test complete");
+  } else {
+    LIBNDT7_EMIT_WARNING("no more hosts to try; failing the test");
+  }
+  return success;
 }
 
 void Client::on_warning(const std::string &msg) const noexcept {
@@ -22633,9 +22645,6 @@ void Client::summary() noexcept {
       LIBNDT7_EMIT_INFO("Upload retransmission: "
         << std::fixed << std::setprecision(2)
         << (summary_.upload_retrans * 100) << "%");
-  }
-  if (web100 != nullptr) {
-    LIBNDT7_EMIT_DEBUG("web100: " << web100.dump());
   }
 }
 


### PR DESCRIPTION
This change updates the docstring for `run()` and updates the retry logic to retry all servers before failing. Previously both upload and download could fail but still return `true`, which was a mistake.

This change also removes other vestigial references to ndt5 and web100.

Fixes: https://github.com/m-lab/ndt7-client-cc/issues/19

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-cc/24)
<!-- Reviewable:end -->
