### PR TITLE
feat(cmake): add install targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,3 +174,8 @@ add_test(NAME simple_test COMMAND ndt7-client-cc
 add_test(NAME modern_test COMMAND ndt7-client-cc
          -ca-bundle-path ${CMAKE_SOURCE_DIR}/third_party/curl.haxx.se/ca/cacert.pem
          -verbose -download -upload -scheme=wss)
+
+INSTALL(PROGRAMS ndt7-client-cc
+        DESTINATION bin)
+INSTALL(FILES ${MK_LIBNDT7_AMALGAMATE_DEST}
+        DESTINATION include/libndt7)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,24 @@ cmake --build .
 ctest -a --output-on-failure .
 ```
 
+## Install artifacts
+
+By default the reference client (`ndt7-client-cc`) and the single include
+libndt7.hpp are installed to system a default location like `/usr/local/`.
+
+```sh
+$ cmake --install .
+-- Install configuration: ""
+-- Installing: /usr/local/bin/ndt7-client-cc
+-- Installing: /usr/local/include/libndt7/libndt7.hpp
+```
+
+You may specify an alternate prefix.
+
+```sh
+cmake --install . --prefix </my/install/prefix>
+```
+
 ## Command line client
 
 Building with CMake also builds a simple command line client. Get usage info

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ $ cmake --install .
 You may specify an alternate prefix.
 
 ```sh
-cmake --install . --prefix </my/install/prefix>
+cmake --install . --prefix /my/install/prefix
 ```
 
 ## Command line client


### PR DESCRIPTION
This change adds two simple install targets for the reference client and single include library. This change also updates the README with hints for specifying an alternate install prefix.

Previously, there were no install targets defined.

Fixes: https://github.com/m-lab/ndt7-client-cc/issues/17

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-cc/26)
<!-- Reviewable:end -->
