### PR TITLE
feat(flag): add -locate-params flag

### DIFF
--- a/ndt7-client-cc.cpp
+++ b/ndt7-client-cc.cpp
@@ -203,7 +203,7 @@ int main(int, char **argv) {
         settings.metadata["key"] = param.second;
         std::clog << "will use this locate api key: " << param.second << std::endl;
       } else if (param.first == "locate-params") {
-        KV commas = {.first = param.second};
+        KV commas = {.first = param.second, .last = ""};
         while (token(commas.first, ",", commas)) {
           KV param;
           if (token(commas.first, "=", param)) {

--- a/ndt7-client-cc.cpp
+++ b/ndt7-client-cc.cpp
@@ -90,7 +90,10 @@ struct KeyValueParserState {
   std::string last;
 };
 
-static bool token(std::string s, std::string sep, KV& kv) {
+// getNextToken returns true if the string @p s contains @p sep and false otherwise. On successful
+// return, the @p kv parser state is mutated and will contain the first token in its .first entry and the rest
+// of the string yet to parse into its .rest entry.
+static bool getNextToken(std::string s, std::string sep, KV &kv) {
   if (s == "") {
     return false;
   }

--- a/ndt7-client-cc.cpp
+++ b/ndt7-client-cc.cpp
@@ -93,15 +93,15 @@ struct KeyValueParserState {
 // getNextToken returns true if the string @p s contains @p sep and false otherwise. On successful
 // return, the @p kv parser state is mutated and will contain the first token in its .first entry and the rest
 // of the string yet to parse into its .rest entry.
-static bool getNextToken(std::string s, std::string sep, KV &kv) {
+static bool getNextToken(std::string s, std::string sep, KeyValueParserState &kv) {
   if (s == "") {
     return false;
   }
   auto p = s.find(sep);
   kv.first = s.substr(0, p);
-  kv.last = "";
+  kv.rest = "";
   if (p != std::string::npos) {
-    kv.last = s.substr(p+1);
+    kv.rest = s.substr(p+1);
   }
   return true;
 }
@@ -206,15 +206,15 @@ int main(int, char **argv) {
         settings.metadata["key"] = param.second;
         std::clog << "will use this locate api key: " << param.second << std::endl;
       } else if (param.first == "locate-params") {
-        KV commas = {.first = param.second, .last = ""};
-        while (token(commas.first, ",", commas)) {
-          KV param;
-          if (token(commas.first, "=", param)) {
-            std::clog << "will use this locate param: " << param.first << " == " << param.last << std::endl;
-            settings.metadata[param.first] = param.last;
+        KeyValueParserState commas = {.first = param.second, .rest = ""};
+        while (getNextToken(commas.first, ",", commas)) {
+          KeyValueParserState param;
+          if (getNextToken(commas.first, "=", param)) {
+            std::clog << "will use this locate param: " << param.first << " == " << param.rest << std::endl;
+            settings.metadata[param.first] = param.rest;
           }
           // Process next parameter.
-          commas.first = commas.last;
+          commas.first = commas.rest;
         }
       } else if (param.first == "locate-api-url") {
         settings.locate_api_base_url = param.second;

--- a/ndt7-client-cc.cpp
+++ b/ndt7-client-cc.cpp
@@ -87,7 +87,7 @@ void BatchClient::summary() noexcept {
 
 struct KeyValueParserState {
   std::string first;
-  std::string last;
+  std::string rest;
 };
 
 // getNextToken returns true if the string @p s contains @p sep and false otherwise. On successful

--- a/ndt7-client-cc.cpp
+++ b/ndt7-client-cc.cpp
@@ -85,7 +85,7 @@ void BatchClient::summary() noexcept {
   std::cout << summary.dump() << std::endl;
 }
 
-struct KV {
+struct KeyValueParserState {
   std::string first;
   std::string last;
 };

--- a/ndt7-client-cc.cpp
+++ b/ndt7-client-cc.cpp
@@ -98,6 +98,7 @@ By default, ndt7-client-cc uses M-Lab's Locate API for unregistered clients
 you may specify an API key for the Locate API using:
 * `-locate-api-key=<key>`
 * `-locate-api-url=<url>`
+* `-locate-param=<name>=<value>`
 
 Instead of the Locate API, you may specify a specific server using a combination
 of the flags:
@@ -139,6 +140,7 @@ int main(int, char **argv) {
     cmdline.add_param("socks5h");
     cmdline.add_param("locate-api-key");
     cmdline.add_param("locate-api-url");
+    cmdline.add_param("locate-param");
     cmdline.add_param("port");
     cmdline.add_param("scheme");
     cmdline.add_param("hostname");
@@ -182,6 +184,11 @@ int main(int, char **argv) {
       } else if (param.first == "locate-api-key") {
         settings.metadata["key"] = param.second;
         std::clog << "will use this locate api key: " << param.second << std::endl;
+      } else if (param.first == "locate-param") {
+        std::string name = param.second.substr(0, param.second.find("="));
+        std::string value = param.second.substr(param.second.find("=")+1);
+        settings.metadata[name] = value;
+        std::clog << "will use this locate param: " << name << " == " << value << std::endl;
       } else if (param.first == "locate-api-url") {
         settings.locate_api_base_url = param.second;
         std::clog << "will use this locate api url: " << param.second << std::endl;


### PR DESCRIPTION
Previously, it was not possible to add additional Locate API parameters without code changes. This change adds a new flag `-locate-params` which accepts multiple `name=value` options separated with a comma. Each will be passed to the Locate API request.

Example:

```sh
./ndt7-client-cc -locate-params=region=US-CA -download
./ndt7-client-cc -locate-params=early_exit=250,region=US-NY -download
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-cc/27)
<!-- Reviewable:end -->
