### PR TITLE
fix: unknown type error on ARM64

### DIFF
--- a/test/libndt7_test.cpp
+++ b/test/libndt7_test.cpp
@@ -4,6 +4,9 @@
 
 #include "third_party/github.com/nlohmann/json/json.hpp"
 
+// We should include this before inculding libndt7.hpp and catch.hpp.
+#include <linux/types.h>
+
 #include "libndt7/libndt7.hpp"
 
 #ifndef _WIN32


### PR DESCRIPTION
When building `libndt7_test.cpp.o` for ARM64, both `libndt7.hpp` and `catch.hpp` will use `<linux/types.h>`. We will get unknown type error for `__u64`, `__u32` and `__u8` if we don't include it first.

Issue: https://github.com/m-lab/ndt7-client-cc/issues/30

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-cc/34)
<!-- Reviewable:end -->
