### PR TITLE
Add user agent to Locate API requests

### DIFF
--- a/include/libndt7/libndt7.hpp
+++ b/include/libndt7/libndt7.hpp
@@ -300,8 +300,8 @@ class Settings {
       {"client_library_name", "m-lab/libndt7-cc"},
   };
 
-  /// userAgent is the user agent provided for Locate API requests.
-  std::string userAgent = "libndt7-cc-agent/v0.1.0";
+  /// user_agent is the user agent provided for Locate API requests.
+  std::string user_agent = "libndt7-cc-agent/v0.1.0";
 
   /// Type of NDT protocol that you want to use. Selecting the protocol may
   /// cause libndt7 to use different default settings for the port or for
@@ -2997,7 +2997,7 @@ class CurlxLoggerAdapter : public internal::Logger {
 bool Client::query_locate_api_curl(const std::string &url, long timeout,
                                std::string *body) noexcept {
   CurlxLoggerAdapter adapter{this};
-  internal::Curlx curlx{adapter, settings_.userAgent};
+  internal::Curlx curlx{adapter, settings_.user_agent};
   return curlx.GetMaybeSOCKS5(settings_.socks5h_port, url, timeout, body);
 }
 

--- a/include/libndt7/libndt7.hpp
+++ b/include/libndt7/libndt7.hpp
@@ -300,6 +300,9 @@ class Settings {
       {"client_library_name", "m-lab/libndt7-cc"},
   };
 
+  /// userAgent is the user agent provided for Locate API requests.
+  std::string userAgent = "libndt7-cc-agent/v0.1.0";
+
   /// Type of NDT protocol that you want to use. Selecting the protocol may
   /// cause libndt7 to use different default settings for the port or for
   /// the Locate API. Clear text ndt7 uses port 80, ndt7-over-TLS uses 443.
@@ -2994,7 +2997,7 @@ class CurlxLoggerAdapter : public internal::Logger {
 bool Client::query_locate_api_curl(const std::string &url, long timeout,
                                std::string *body) noexcept {
   CurlxLoggerAdapter adapter{this};
-  internal::Curlx curlx{adapter};
+  internal::Curlx curlx{adapter, settings_.userAgent};
   return curlx.GetMaybeSOCKS5(settings_.socks5h_port, url, timeout, body);
 }
 

--- a/ndt7-client-cc.cpp
+++ b/ndt7-client-cc.cpp
@@ -165,6 +165,7 @@ int main(int, char **argv) {
     cmdline.add_param("port");
     cmdline.add_param("scheme");
     cmdline.add_param("hostname");
+    cmdline.add_param("user-agent");
     cmdline.parse(argv);
     for (auto &flag : cmdline.flags()) {
       if (flag == "download") {
@@ -228,6 +229,9 @@ int main(int, char **argv) {
       } else if (param.first == "hostname") {
         settings.hostname = param.second;
         std::clog << "will use this hostname: " << param.second << std::endl;
+      } else if (param.first == "user-agent") {
+        settings.userAgent = param.second;
+        std::clog << "will use this user-agent: " << param.second << std::endl;
       } else if (param.first == "socks5h") {
         settings.socks5h_port = param.second;
         std::clog << "will use the socks5h proxy at: 127.0.0.1:" << param.second << std::endl;

--- a/ndt7-client-cc.cpp
+++ b/ndt7-client-cc.cpp
@@ -230,7 +230,7 @@ int main(int, char **argv) {
         settings.hostname = param.second;
         std::clog << "will use this hostname: " << param.second << std::endl;
       } else if (param.first == "user-agent") {
-        settings.userAgent = param.second;
+        settings.user_agent = param.second;
         std::clog << "will use this user-agent: " << param.second << std::endl;
       } else if (param.first == "socks5h") {
         settings.socks5h_port = param.second;

--- a/single_include/libndt7.hpp
+++ b/single_include/libndt7.hpp
@@ -21954,8 +21954,8 @@ class Settings {
       {"client_library_name", "m-lab/libndt7-cc"},
   };
 
-  /// userAgent is the user agent provided for Locate API requests.
-  std::string userAgent = "libndt7-cc-agent/v0.1.0";
+  /// user_agent is the user agent provided for Locate API requests.
+  std::string user_agent = "libndt7-cc-agent/v0.1.0";
 
   /// Type of NDT protocol that you want to use. Selecting the protocol may
   /// cause libndt7 to use different default settings for the port or for
@@ -24651,7 +24651,7 @@ class CurlxLoggerAdapter : public internal::Logger {
 bool Client::query_locate_api_curl(const std::string &url, long timeout,
                                std::string *body) noexcept {
   CurlxLoggerAdapter adapter{this};
-  internal::Curlx curlx{adapter, settings_.userAgent};
+  internal::Curlx curlx{adapter, settings_.user_agent};
   return curlx.GetMaybeSOCKS5(settings_.socks5h_port, url, timeout, body);
 }
 

--- a/single_include/libndt7.hpp
+++ b/single_include/libndt7.hpp
@@ -21282,6 +21282,8 @@ class Curlx {
  public:
   explicit Curlx(const Logger &logger) noexcept;
 
+  explicit Curlx(const Logger &logger, const std::string &agent) noexcept;
+
   virtual bool GetMaybeSOCKS5(const std::string &proxy_port,
                               const std::string &url, long timeout,
                               std::string *body) noexcept;
@@ -21297,6 +21299,9 @@ class Curlx {
 
   virtual CURLcode SetoptWriteFunction(UniqueCurl &handle,
                                        CurlWriteCb callback) noexcept;
+
+  virtual CURLcode SetoptUserAgent(UniqueCurl &handle,
+                                   const std::string &agent) noexcept;
 
   virtual CURLcode SetoptWriteData(UniqueCurl &handle, void *pointer) noexcept;
 
@@ -21315,6 +21320,7 @@ class Curlx {
 
  private:
   const Logger &logger_;
+  const std::string agent_;
 };
 
 }  // namespace internal
@@ -21358,7 +21364,9 @@ void CurlDeleter::operator()(CURL *handle) noexcept {
   }
 }
 
-Curlx::Curlx(const Logger &logger) noexcept : logger_{logger} {}
+Curlx::Curlx(const Logger &logger) noexcept : logger_{logger}, agent_{"default-ndt7-client-cc-agent"} {}
+
+Curlx::Curlx(const Logger &logger, const std::string &agent) noexcept : logger_{logger}, agent_{agent} {}
 
 bool Curlx::GetMaybeSOCKS5(const std::string &proxy_port,
                            const std::string &url, long timeout,
@@ -21398,6 +21406,10 @@ bool Curlx::Get(UniqueCurl &handle, const std::string &url, long timeout,
   if (this->SetoptWriteData(handle, &ss) != CURLE_OK) {
     LIBNDT7_LOGGER_WARNING(logger_,
                            "curlx: cannot set callback function context");
+    return false;
+  }
+  if (this->SetoptUserAgent(handle, this->agent_) != CURLE_OK) {
+    LIBNDT7_LOGGER_WARNING(logger_, "curlx: cannot set user agent");
     return false;
   }
   if (this->SetoptTimeout(handle, timeout) != CURLE_OK) {
@@ -21448,6 +21460,12 @@ CURLcode Curlx::SetoptWriteFunction(UniqueCurl &handle,
                                     CurlWriteCb callback) noexcept {
   LIBNDT7_ASSERT(handle);
   return ::curl_easy_setopt(handle.get(), CURLOPT_WRITEFUNCTION, callback);
+}
+
+CURLcode Curlx::SetoptUserAgent(UniqueCurl &handle,
+                                const std::string &agent) noexcept {
+  LIBNDT7_ASSERT(handle);
+  return ::curl_easy_setopt(handle.get(), CURLOPT_USERAGENT, agent.c_str());
 }
 
 CURLcode Curlx::SetoptWriteData(UniqueCurl &handle, void *pointer) noexcept {
@@ -21935,6 +21953,9 @@ class Settings {
       {"client_library_version", "v0.1.0"},
       {"client_library_name", "m-lab/libndt7-cc"},
   };
+
+  /// userAgent is the user agent provided for Locate API requests.
+  std::string userAgent = "libndt7-cc-agent/v0.1.0";
 
   /// Type of NDT protocol that you want to use. Selecting the protocol may
   /// cause libndt7 to use different default settings for the port or for
@@ -24630,7 +24651,7 @@ class CurlxLoggerAdapter : public internal::Logger {
 bool Client::query_locate_api_curl(const std::string &url, long timeout,
                                std::string *body) noexcept {
   CurlxLoggerAdapter adapter{this};
-  internal::Curlx curlx{adapter};
+  internal::Curlx curlx{adapter, settings_.userAgent};
   return curlx.GetMaybeSOCKS5(settings_.socks5h_port, url, timeout, body);
 }
 


### PR DESCRIPTION
This change adds support for providing a user-agent string and propagating this string to the request to the Locate API. With this change, client installations may provide unique user agents identifiable to the Locate API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-cc/42)
<!-- Reviewable:end -->
