### PR TITLE
Rename argument with unit suffix

### DIFF
--- a/include/libndt7/libndt7.cpp
+++ b/include/libndt7/libndt7.cpp
@@ -236,8 +236,8 @@ static void random_printable_fill(char *buffer, size_t length) noexcept {
   }
 }
 
-double compute_speed_kbits(double data, double elapsed) noexcept {
-  return (elapsed > 0.0) ? ((data * 8.0) / 1000.0 / elapsed) : 0.0;
+double compute_speed_kbits(double data_bytes, double elapsed_sec) noexcept {
+  return (elapsed_sec > 0.0) ? ((data_bytes * 8.0) / 1000.0 / elapsed_sec) : 0.0;
 }
 
 // format_speed_from_kbits format the input speed, which must be in kbit/s, to
@@ -258,8 +258,8 @@ static std::string format_speed_from_kbits(double speed) noexcept {
   return ss.str();
 }
 
-std::string format_speed_from_kbits(double data, double elapsed) noexcept {
-  return format_speed_from_kbits(compute_speed_kbits(data, elapsed));
+std::string format_speed_from_kbits(double data_bytes, double elapsed_sec) noexcept {
+  return format_speed_from_kbits(compute_speed_kbits(data_bytes, elapsed_sec));
 }
 
 static std::string represent(std::string message) noexcept {
@@ -424,19 +424,19 @@ void Client::on_debug(const std::string &msg) const noexcept {
 
 void Client::on_performance(NettestFlags tid, uint8_t nflows,
                             double measured_bytes,
-                            double elapsed_time, double max_runtime) noexcept {
+                            double elapsed_sec, double max_runtime) noexcept {
   auto percent = 0.0;
   if (max_runtime > 0.0) {
-    percent = (elapsed_time * 100.0 / max_runtime);
+    percent = (elapsed_sec * 100.0 / max_runtime);
   }
   LIBNDT7_EMIT_INFO("  [" << std::fixed << std::setprecision(0) << std::setw(2)
                   << std::right << percent << "%] speed: "
-                  << format_speed_from_kbits(measured_bytes, elapsed_time));
+                  << format_speed_from_kbits(measured_bytes, elapsed_sec));
 
   LIBNDT7_EMIT_DEBUG("  [" << std::fixed << std::setprecision(0) << std::setw(2)
                   << std::right << percent << "%]"
                   << " elapsed: " << std::fixed << std::setprecision(3)
-                  << std::setw(6) << elapsed_time << " s;"
+                  << std::setw(6) << elapsed_sec << " s;"
                   << " test_id: " << (int)tid << "; num_flows: " << (int)nflows
                   << "; measured_bytes: " << measured_bytes);
 }

--- a/include/libndt7/libndt7.h
+++ b/include/libndt7/libndt7.h
@@ -82,9 +82,9 @@ UrlParts parse_ws_url(const std::string& url);
 std::string format_http_params(const std::map<std::string, std::string>& params);
 
 // Utility functions.
-double compute_speed_kbits(double data, double elapsed) noexcept;
+double compute_speed_kbits(double data_bytes, double elapsed_sec) noexcept;
 
-std::string format_speed_from_kbits(double data, double elapsed) noexcept;
+std::string format_speed_from_kbits(double data_bytes, double elapsed_sec) noexcept;
 
 // Versioning
 // ``````````
@@ -170,16 +170,16 @@ class EventHandler {
   /// to write the provided information as an info message. @param tid is either
   /// nettest_flag_download or nettest_flag_upload. @param nflows is the number
   /// of used flows. @param measured_bytes is the number of bytes received
-  /// or sent since the beginning of the measurement. @param elapsed
+  /// or sent since the beginning of the measurement. @param elapsed_sec
   /// is the number of seconds elapsed since the beginning of the nettest.
   /// @param max_runtime is the maximum runtime of this nettest, as copied from
-  /// the Settings. @remark By dividing @p elapsed by @p max_runtime, you can
+  /// the Settings. @remark By dividing @p elapsed_sec by @p max_runtime, you can
   /// get the percentage of completion of the current nettest. @remark We
   /// provide you with @p tid, so you know whether the nettest is downloading
   /// bytes from the server or uploading bytes to the server. \warning This
   /// method could be called from another thread context.
   virtual void on_performance(NettestFlags tid, uint8_t nflows,
-                              double measured_bytes, double elapsed,
+                              double measured_bytes, double elapsed_sec,
                               double max_runtime) noexcept = 0;
 
   /// Called to provide you with NDT results. The default behavior is to write
@@ -359,7 +359,7 @@ class Client : public EventHandler {
   void on_performance(NettestFlags tid,
                       uint8_t nflows,
                       double measured_bytes,
-                      double elapsed,
+                      double elapsed_sec,
                       double max_runtime) noexcept override;
 
   void on_result(std::string scope, std::string name,

--- a/single_include/libndt7.hpp
+++ b/single_include/libndt7.hpp
@@ -21736,9 +21736,9 @@ UrlParts parse_ws_url(const std::string& url);
 std::string format_http_params(const std::map<std::string, std::string>& params);
 
 // Utility functions.
-double compute_speed_kbits(double data, double elapsed) noexcept;
+double compute_speed_kbits(double data_bytes, double elapsed_sec) noexcept;
 
-std::string format_speed_from_kbits(double data, double elapsed) noexcept;
+std::string format_speed_from_kbits(double data_bytes, double elapsed_sec) noexcept;
 
 // Versioning
 // ``````````
@@ -21824,16 +21824,16 @@ class EventHandler {
   /// to write the provided information as an info message. @param tid is either
   /// nettest_flag_download or nettest_flag_upload. @param nflows is the number
   /// of used flows. @param measured_bytes is the number of bytes received
-  /// or sent since the beginning of the measurement. @param elapsed
+  /// or sent since the beginning of the measurement. @param elapsed_sec
   /// is the number of seconds elapsed since the beginning of the nettest.
   /// @param max_runtime is the maximum runtime of this nettest, as copied from
-  /// the Settings. @remark By dividing @p elapsed by @p max_runtime, you can
+  /// the Settings. @remark By dividing @p elapsed_sec by @p max_runtime, you can
   /// get the percentage of completion of the current nettest. @remark We
   /// provide you with @p tid, so you know whether the nettest is downloading
   /// bytes from the server or uploading bytes to the server. \warning This
   /// method could be called from another thread context.
   virtual void on_performance(NettestFlags tid, uint8_t nflows,
-                              double measured_bytes, double elapsed,
+                              double measured_bytes, double elapsed_sec,
                               double max_runtime) noexcept = 0;
 
   /// Called to provide you with NDT results. The default behavior is to write
@@ -22013,7 +22013,7 @@ class Client : public EventHandler {
   void on_performance(NettestFlags tid,
                       uint8_t nflows,
                       double measured_bytes,
-                      double elapsed,
+                      double elapsed_sec,
                       double max_runtime) noexcept override;
 
   void on_result(std::string scope, std::string name,
@@ -22497,8 +22497,8 @@ static void random_printable_fill(char *buffer, size_t length) noexcept {
   }
 }
 
-double compute_speed_kbits(double data, double elapsed) noexcept {
-  return (elapsed > 0.0) ? ((data * 8.0) / 1000.0 / elapsed) : 0.0;
+double compute_speed_kbits(double data_bytes, double elapsed_sec) noexcept {
+  return (elapsed_sec > 0.0) ? ((data_bytes * 8.0) / 1000.0 / elapsed_sec) : 0.0;
 }
 
 // format_speed_from_kbits format the input speed, which must be in kbit/s, to
@@ -22519,8 +22519,8 @@ static std::string format_speed_from_kbits(double speed) noexcept {
   return ss.str();
 }
 
-std::string format_speed_from_kbits(double data, double elapsed) noexcept {
-  return format_speed_from_kbits(compute_speed_kbits(data, elapsed));
+std::string format_speed_from_kbits(double data_bytes, double elapsed_sec) noexcept {
+  return format_speed_from_kbits(compute_speed_kbits(data_bytes, elapsed_sec));
 }
 
 static std::string represent(std::string message) noexcept {
@@ -22685,19 +22685,19 @@ void Client::on_debug(const std::string &msg) const noexcept {
 
 void Client::on_performance(NettestFlags tid, uint8_t nflows,
                             double measured_bytes,
-                            double elapsed_time, double max_runtime) noexcept {
+                            double elapsed_sec, double max_runtime) noexcept {
   auto percent = 0.0;
   if (max_runtime > 0.0) {
-    percent = (elapsed_time * 100.0 / max_runtime);
+    percent = (elapsed_sec * 100.0 / max_runtime);
   }
   LIBNDT7_EMIT_INFO("  [" << std::fixed << std::setprecision(0) << std::setw(2)
                   << std::right << percent << "%] speed: "
-                  << format_speed_from_kbits(measured_bytes, elapsed_time));
+                  << format_speed_from_kbits(measured_bytes, elapsed_sec));
 
   LIBNDT7_EMIT_DEBUG("  [" << std::fixed << std::setprecision(0) << std::setw(2)
                   << std::right << percent << "%]"
                   << " elapsed: " << std::fixed << std::setprecision(3)
-                  << std::setw(6) << elapsed_time << " s;"
+                  << std::setw(6) << elapsed_sec << " s;"
                   << " test_id: " << (int)tid << "; num_flows: " << (int)nflows
                   << "; measured_bytes: " << measured_bytes);
 }


### PR DESCRIPTION
Update the argument name with clear unit.

* Rename `elapsed` to `elapsed_sec`.
* Rename `data` to `data_bytes`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-cc/43)
<!-- Reviewable:end -->
