### PR TITLE
Mark the functions in Client as virtual

### DIFF
--- a/include/libndt7/libndt7.h
+++ b/include/libndt7/libndt7.h
@@ -346,11 +346,11 @@ class Client : public EventHandler {
   /// returns true. When using the Locate API, `run` will attempt a test with
   /// multiple servers, stopping on the first success or continue trying the
   /// next server on failure. If all attempts fail, `run` returns false.
-  bool run() noexcept;
+  virtual bool run() noexcept;
 
   // After running a successful test with `run`, `get_summary` returns the test
   // summary metrics.
-  SummaryData get_summary() noexcept;
+  virtual SummaryData get_summary() noexcept;
 
   void on_warning(const std::string &s) const noexcept override;
 

--- a/single_include/libndt7.hpp
+++ b/single_include/libndt7.hpp
@@ -22000,11 +22000,11 @@ class Client : public EventHandler {
   /// returns true. When using the Locate API, `run` will attempt a test with
   /// multiple servers, stopping on the first success or continue trying the
   /// next server on failure. If all attempts fail, `run` returns false.
-  bool run() noexcept;
+  virtual bool run() noexcept;
 
   // After running a successful test with `run`, `get_summary` returns the test
   // summary metrics.
-  SummaryData get_summary() noexcept;
+  virtual SummaryData get_summary() noexcept;
 
   void on_warning(const std::string &s) const noexcept override;
 


### PR DESCRIPTION
Mark `run` and `get_summary` as virtual so that we can override them during unit tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-cc/47)
<!-- Reviewable:end -->
